### PR TITLE
fixed key error bug

### DIFF
--- a/digitalocean/Manager.py
+++ b/digitalocean/Manager.py
@@ -20,7 +20,7 @@ class Manager(object):
         data = r.json()
         self.call_response = data
         if data['status'] != "OK":
-            raise Exception(data[u'error_message'])
+            raise Exception(data[u'message'])
         return data
 
     def get_all_regions(self):


### PR DESCRIPTION
When access is denied due to bad api_key, error message has a key error which prevents error message from DigitalOcean from showing.
