### PR TITLE
Message source in case of non OK status

### DIFF
--- a/digitalocean/Domain.py
+++ b/digitalocean/Domain.py
@@ -24,7 +24,8 @@ class Domain(object):
         data = r.json()
         self.call_response = data
         if data['status'] != "OK":
-            raise Exception(data[u'message'])
+            msg = [data[m] for m in ("message", "error_message", "status") if m in data][0]
+            raise Exception(msg)
    
         return data
 

--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -27,7 +27,8 @@ class Droplet(object):
         data = r.json()
         self.call_response = data
         if data['status'] != "OK":
-            raise Exception(data[u'message'])
+            msg = [data[m] for m in ("message", "error_message", "status") if m in data][0]
+            raise Exception(msg)
         #add the event to the object's event list.
         event_id = data.get(u'event_id',None)
         if not event_id and u'event_id' in data.get(u'droplet',{}):

--- a/digitalocean/Event.py
+++ b/digitalocean/Event.py
@@ -18,7 +18,8 @@ class Event(object):
         data = r.json()
         self.call_response = data
         if data['status'] != "OK":            
-            raise Exception(data[u'message'])
+            msg = [data[m] for m in ("message", "error_message", "status") if m in data][0]
+            raise Exception(msg)
         return data
 
     def load(self):

--- a/digitalocean/Image.py
+++ b/digitalocean/Image.py
@@ -16,7 +16,8 @@ class Image(object):
         data = r.json()
         self.call_response = data
         if data['status'] != "OK":
-            raise Exception(data[u'message'])
+            msg = [data[m] for m in ("message", "error_message", "status") if m in data][0]
+            raise Exception(msg)
    
         return data
 

--- a/digitalocean/Manager.py
+++ b/digitalocean/Manager.py
@@ -20,7 +20,8 @@ class Manager(object):
         data = r.json()
         self.call_response = data
         if data['status'] != "OK":
-            raise Exception(data[u'message'])
+            msg = [data[m] for m in ("message", "error_message", "status") if m in data][0]
+            raise Exception(msg)
         return data
 
     def get_all_regions(self):

--- a/digitalocean/Record.py
+++ b/digitalocean/Record.py
@@ -21,7 +21,8 @@ class Record(object):
         data = r.json()
         self.call_response = data
         if data['status'] != "OK":            
-            raise Exception(data[u'message'])
+            msg = [data[m] for m in ("message", "error_message", "status") if m in data][0]
+            raise Exception(msg)
         return data
 
     def create(self):

--- a/digitalocean/SSHKey.py
+++ b/digitalocean/SSHKey.py
@@ -22,7 +22,8 @@ class SSHKey(object):
         data = r.json()
         self.call_response = data
         if data['status'] != "OK":
-            raise Exception(data[u'message'])
+            msg = [data[m] for m in ("message", "error_message", "status") if m in data][0]
+            raise Exception(msg)
 
         return data
 


### PR DESCRIPTION
Current codes tries to throw a message with data['message'] in case if status is not "OK"
However the latest digitalocean API has "error_message" instead of "message":
{
status: "ERROR",
error_message: "The image you specified is not available in the selected region, you can make it globally available by initiating an image region transfer from the images tab."
}

Added code to check both "message" and "error_message". If none exists (which should not happen), it gives back the content of "status".
