### PR TITLE
Fixed SSH keys parameter

### DIFF
--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -15,6 +15,7 @@ class Droplet(object):
         self.ip_address = None
         self.private_ip_address = None
         self.call_reponse = None
+        self.ssh_key_ids = None
         self.events = []
 
         #Setting the attribute values
@@ -139,6 +140,7 @@ class Droplet(object):
                 "size_id": self.size_id,
                 "image_id": self.image_id,
                 "region_id": self.region_id,
+                "ssh_key_ids": self.ssh_key_ids
             }
 
         if ssh_key_ids:


### PR DESCRIPTION
Hi,

I've tried to create a new droplet on Digitalocean and noticed, that the parameter for the SSH keys isn't passed properly. 
With the changes, the creation of droplets with and without SSH key authentication is working fine again.

This is my first pull request and my Python is a little rusty, so bear with me :) There might be a more elegant way to solve this. 

Anyway, I hope it helps to improve the library.

-Chris
