### PR TITLE
Set scrub_data to True by default.

### DIFF
--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -129,7 +129,7 @@ class Droplet(object):
         """
             Destroy the droplet
         """
-        self.__call_api("/destroy/", {'scrub_data': 'true' if scrub_data else 'false'})
+        self.__call_api("/destroy/", {'scrub_data': '1' if scrub_data else '0'})
 
     def create(self, ssh_key_ids=None, virtio=False, private_networking=False):
         """


### PR DESCRIPTION
Considering all the outcry in https://github.com/fog/fog/issues/2525, https://github.com/fog/fog/pull/2526, HackerNews and on Twitter, let's just change this to scrub data by default.

People don't always use the optional arguments, but in this case they should. If they want the speed up from not scrubbing data, they can set it to False (as they have to do in Fog as well now).
