### PR TITLE
Fix infinite loop when dealing with pagination.

### DIFF
--- a/digitalocean/Manager.py
+++ b/digitalocean/Manager.py
@@ -35,7 +35,7 @@ class Manager(BaseAPI):
             key, values = data.popitem()
             for page in range(2, int(pages) + 1):
                 params.update({'page': page})
-                new_data = self.get_data(url, params=params)
+                new_data = super(Manager, self).get_data(url, params=params)
 
                 more_values = new_data.values()[0]
                 for value in more_values:


### PR DESCRIPTION
There is an infinite loop when dealing with pagination. This can be most easily seen with:

```
images = manager.get_all_images()
```

This is because it calls `self.get_data` which in turn calls `self.__deal_with_pagination` again. And so, and so on... :smile: 
