### PR TITLE
Add docstrings

### DIFF
--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -7,6 +7,37 @@ from .baseapi import BaseAPI
 from .SSHKey import SSHKey
 
 class Droplet(BaseAPI):
+    """"Droplet managment
+
+    Attributes:
+        id: int - droplet id
+        name: str - name
+        memory: str - memory size
+        vcpus: int - number of vcpus
+        disk: str - disk size
+        region: str - region
+        status: str - status
+        image: str - image name to use to create droplet
+        size_slug: str - droplet size
+        locked: bool - True if locked
+        created_at:
+        status: str - status
+        networks:
+        kernel: str - kernel
+        backup_ids: [int] - list of ids of backups of this droplet
+        snapshot_ids: [int] - list of ids of snapshots of this droplet
+        action_ids: [int] - list of ids of actions
+        features:
+        ip_address: [str] - list of public ip addresses assigned
+        private_ip_address: [str] - list of private ip addresses assigned
+        ip_v6_address: [str] - list of ipv6 addresses assigned
+        ssh_keys: [str] - list of ssh keys
+        backups: bool - True if backups enabled
+        ipv6: bool - True if ipv6 enabled
+        private_networking: bool - True if private networking enabled
+        user_data: str - arbitrary data to pass to droplet
+    """
+
     def __init__(self, *args, **kwargs):
         # Defining default values
         self.id = None
@@ -144,6 +175,9 @@ class Droplet(BaseAPI):
     def resize(self, new_size_slug):
         """
             resize the droplet to a new size slug.
+
+        Args:
+            new_size_slug: str - name of new size
         """
         return self.get_data(
             "droplets/%s/actions/" % self.id,


### PR DESCRIPTION
Would you accept some patches to add docstrings to classes and methods?

While using the module in ipython I found I kept having to refer to the DO online documentation, or to read the python source to try to figure opt what arguments to use. I think it would be very helpful to have docstrings that described these so that they could be accessed directly from ipython etc.

As it stands this pull request is incomplete - if you are in favour of it I will add more commits to make the existing docstrings more accurate and informative and to add docstrings to other classes and methods
