### PR TITLE
Optionally return Action when calling methods in Droplet that perform Droplet actions

### DIFF
--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -138,115 +138,175 @@ class Droplet(BaseAPI):
             self.ip_v6_address = self.networks['v6'][0]['ip_address']
         return self
 
-    def power_on(self):
+    def _perform_action(self, params, return_dict=True):
+        """
+            Perform a droplet action.
+
+            Args:
+                params - dict : parameters of the action
+
+            Optional Args:
+                return_dict - bool : Return a dict when True (default),
+                    otherwise return an Action.
+
+            Returns dict or Action
+        """
+        action = self.get_data(
+            "droplets/%s/actions/" % self.id,
+            type="POST",
+            params=params
+        )
+        if return_dict:
+            return action
+        else:
+            action = action[u'action']
+            return_action = Action()
+            # Loading attributes
+            for attr in action.keys():
+                setattr(return_action, attr, action[attr])
+            return return_action
+
+    def power_on(self, return_dict=True):
         """
             Boot up the droplet
-        """
-        return self.get_data(
-            "droplets/%s/actions/" % self.id,
-            type="POST",
-            params={'type': 'power_on'}
-        )
 
-    def shutdown(self):
+            Optional Args:
+                return_dict - bool : Return a dict when True (default),
+                    otherwise return an Action.
+
+            Returns dict or Action
+        """
+        return self._perform_action({'type': 'power_on'}, return_dict)
+
+    def shutdown(self, return_dict=True):
         """
             shutdown the droplet
-        """
-        return self.get_data(
-            "droplets/%s/actions/" % self.id,
-            type="POST",
-            params={'type': 'shutdown'}
-        )
 
-    def reboot(self):
+            Optional Args:
+                return_dict - bool : Return a dict when True (default),
+                    otherwise return an Action.
+
+            Returns dict or Action
+        """
+        return self._perform_action({'type': 'shutdown'}, return_dict)
+
+    def reboot(self, return_dict=True):
         """
             restart the droplet
-        """
-        return self.get_data(
-            "droplets/%s/actions/" % self.id,
-            type="POST",
-            params={'type': 'reboot'}
-        )
 
-    def power_cycle(self):
+            Optional Args:
+                return_dict - bool : Return a dict when True (default),
+                    otherwise return an Action.
+
+            Returns dict or Action
+        """
+        return self._perform_action({'type': 'reboot'}, return_dict)
+
+    def power_cycle(self, return_dict=True):
         """
             restart the droplet
-        """
-        return self.get_data(
-            "droplets/%s/actions/" % self.id,
-            type="POST",
-            params={'type': 'power_cycle'}
-        )
 
-    def power_off(self):
+            Optional Args:
+                return_dict - bool : Return a dict when True (default),
+                    otherwise return an Action.
+
+            Returns dict or Action
+        """
+        return self._perform_action({'type': 'power_cycle'}, return_dict)
+
+    def power_off(self, return_dict=True):
         """
             restart the droplet
-        """
-        return self.get_data(
-            "droplets/%s/actions/" % self.id,
-            type="POST",
-            params={'type': 'power_off'}
-        )
 
-    def reset_root_password(self):
+            Optional Args:
+                return_dict - bool : Return a dict when True (default),
+                    otherwise return an Action.
+
+            Returns dict or Action
+        """
+        return self._perform_action({'type': 'power_off'}, return_dict)
+
+    def reset_root_password(self, return_dict=True):
         """
             reset the root password
-        """
-        return self.get_data(
-            "droplets/%s/actions/" % self.id,
-            type="POST",
-            params={'type': 'password_reset'}
-        )
 
-    def resize(self, new_size_slug):
+            Optional Args:
+                return_dict - bool : Return a dict when True (default),
+                    otherwise return an Action.
+
+            Returns dict or Action
+        """
+        return self._perform_action({'type': 'password_reset'}, return_dict)
+
+    def resize(self, new_size_slug, return_dict=True):
         """Resize the droplet to a new size slug.
 
         Args:
             new_size_slug: str - name of new size
+
+        Optional Args:
+            return_dict - bool : Return a dict when True (default),
+                otherwise return an Action.
+
+        Returns dict or Action
         """
-        return self.get_data(
-            "droplets/%s/actions/" % self.id,
-            type="POST",
-            params={"type": "resize", "size": new_size_slug}
+        return self._perform_action(
+            {"type": "resize", "size": new_size_slug},
+            return_dict
         )
 
-    def take_snapshot(self, snapshot_name):
+    def take_snapshot(self, snapshot_name, return_dict=True):
         """Take a snapshot!
 
         Args:
             snapshot_name: str - name of snapshot
+
+        Optional Args:
+            return_dict - bool : Return a dict when True (default),
+                otherwise return an Action.
+
+        Returns dict or Action
         """
-        return self.get_data(
-            "droplets/%s/actions/" % self.id,
-            type="POST",
-            params={"type": "snapshot", "name": snapshot_name}
+        return self._perform_action(
+            {"type": "snapshot", "name": snapshot_name},
+            return_dict
         )
 
-    def restore(self, image_id):
+    def restore(self, image_id, return_dict=True):
         """Restore the droplet to an image ( snapshot or backup )
 
         Args:
             image_id : int - id of image
+
+        Optional Args:
+            return_dict - bool : Return a dict when True (default),
+                otherwise return an Action.
+
+        Returns dict or Action
         """
-        return self.get_data(
-            "droplets/%s/actions/" % self.id,
-            type="POST",
-            params={"type": "restore", "image": image_id}
+        return self._perform_action(
+            {"type": "restore", "image": image_id},
+            return_dict
         )
 
-    def rebuild(self, image_id=None):
+    def rebuild(self, image_id=None, return_dict=True):
         """Restore the droplet to an image ( snapshot or backup )
 
         Args:
             image_id : int - id of image
+
+        Optional Args:
+            return_dict - bool : Return a dict when True (default),
+                otherwise return an Action.
+
+        Returns dict or Action
         """
         if not image_id:
             image_id = self.image['id']
 
-        return self.get_data(
-            "droplets/%s/actions/" % self.id,
-            type="POST",
-            params={"type": "rebuild", "image": image_id}
+        return self._perform_action(
+            {"type": "rebuild", "image": image_id},
+            return_dict
         )
 
     def enable_backups(self):
@@ -255,70 +315,92 @@ class Droplet(BaseAPI):
         """
         print("Not yet implemented in APIv2")
 
-    def disable_backups(self):
+    def disable_backups(self, return_dict=True):
         """
             Disable automatic backups
+
+            Optional Args:
+                return_dict - bool : Return a dict when True (default),
+                    otherwise return an Action.
+
+            Returns dict or Action
         """
-        return self.get_data(
-            "droplets/%s/actions/" % self.id,
-            type="POST",
-            params={'type': 'disable_backups'}
-        )
+        return self._perform_action({'type': 'disable_backups'}, return_dict)
 
     def destroy(self):
         """
             Destroy the droplet
+
+            Optional Args:
+                return_dict - bool : Return a dict when True (default),
+                    otherwise return an Action.
+
+            Returns dict or Action
         """
         return self.get_data(
             "droplets/%s" % self.id,
             type="DELETE"
         )
 
-    def rename(self, name):
+    def rename(self, name, return_dict=True):
         """Rename the droplet
 
         Args:
             name : str - new name
+
+        Optional Args:
+            return_dict - bool : Return a dict when True (default),
+                otherwise return an Action.
+
+        Returns dict or Action
         """
-        return self.get_data(
-            "droplets/%s/actions/" % self.id,
-            type="POST",
-            params={'type': 'rename', 'name': name}
+        return self._perform_action(
+            {'type': 'rename', 'name': name},
+            return_dict
         )
 
-    def enable_private_networking(self):
+    def enable_private_networking(self, return_dict=True):
         """
            Enable private networking on an existing Droplet where available.
-        """
-        return self.get_data(
-            "droplets/%s/actions/" % self.id,
-            type="POST",
-            params={'type': 'enable_private_networking'}
-        )
 
-    def enable_ipv6(self):
+           Optional Args:
+               return_dict - bool : Return a dict when True (default),
+                   otherwise return an Action.
+
+           Returns dict or Action
+        """
+        return self._perform_action({'type': 'enable_private_networking'}, return_dict)
+
+    def enable_ipv6(self, return_dict=True):
         """
             Enable IPv6 on an existing Droplet where available.
-        """
-        return self.get_data(
-            "droplets/%s/actions/" % self.id,
-            type="POST",
-            params={'type': 'enable_ipv6'}
-        )
 
-    def change_kernel(self, kernel):
+            Optional Args:
+                return_dict - bool : Return a dict when True (default),
+                    otherwise return an Action.
+
+            Returns dict or Action
+        """
+        return self._perform_action({'type': 'enable_ipv6'}, return_dict)
+
+    def change_kernel(self, kernel, return_dict=True):
         """Change the kernel to a new one
 
         Args:
             kernel : instance of digitalocean.Kernel.Kernel
+
+        Optional Args:
+            return_dict - bool : Return a dict when True (default),
+                otherwise return an Action.
+
+        Returns dict or Action
         """
         if type(kernel) != Kernel:
             raise BadKernelObject("Use Kernel object")
 
-        return self.get_data(
-            "droplets/%s/actions/" % self.id,
-            type="POST",
-            params={'type': 'change_kernel', 'kernel': kernel.id}
+        return self._perform_action(
+            {'type': 'change_kernel', 'kernel': kernel.id},
+            return_dict
         )
 
     def __get_ssh_keys_id(self):

--- a/digitalocean/tests/test_droplet.py
+++ b/digitalocean/tests/test_droplet.py
@@ -75,6 +75,25 @@ class TestDroplet(unittest.TestCase):
         self.assertEqual(response['action']['resource_type'], "droplet")
 
     @responses.activate
+    def test_power_off_action(self):
+        data = self.load_from_file('droplet_actions/power_off.json')
+
+        responses.add(responses.POST, self.actions_url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        response = self.droplet.power_off(False)
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.actions_url + "?type=power_off")
+        self.assertEqual(response.id, 54321)
+        self.assertEqual(response.status, "in-progress")
+        self.assertEqual(response.type, "power_off")
+        self.assertEqual(response.resource_id, 12345)
+        self.assertEqual(response.resource_type, "droplet")
+
+    @responses.activate
     def test_power_on(self):
         data = self.load_from_file('droplet_actions/power_on.json')
 
@@ -92,6 +111,25 @@ class TestDroplet(unittest.TestCase):
         self.assertEqual(response['action']['type'], "power_on")
         self.assertEqual(response['action']['resource_id'], 12345)
         self.assertEqual(response['action']['resource_type'], "droplet")
+
+    @responses.activate
+    def test_power_on_action(self):
+        data = self.load_from_file('droplet_actions/power_on.json')
+
+        responses.add(responses.POST, self.actions_url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        response = self.droplet.power_on(return_dict=False)
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.actions_url + "?type=power_on")
+        self.assertEqual(response.id, 54321)
+        self.assertEqual(response.status, "in-progress")
+        self.assertEqual(response.type, "power_on")
+        self.assertEqual(response.resource_id, 12345)
+        self.assertEqual(response.resource_type, "droplet")
 
     @responses.activate
     def test_shutdown(self):
@@ -113,6 +151,25 @@ class TestDroplet(unittest.TestCase):
         self.assertEqual(response['action']['resource_type'], "droplet")
 
     @responses.activate
+    def test_shutdown_action(self):
+        data = self.load_from_file('droplet_actions/shutdown.json')
+
+        responses.add(responses.POST, self.actions_url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        response = self.droplet.shutdown(return_dict=False)
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.actions_url + "?type=shutdown")
+        self.assertEqual(response.id, 54321)
+        self.assertEqual(response.status, "in-progress")
+        self.assertEqual(response.type, "shutdown")
+        self.assertEqual(response.resource_id, 12345)
+        self.assertEqual(response.resource_type, "droplet")
+
+    @responses.activate
     def test_reboot(self):
         data = self.load_from_file('droplet_actions/reboot.json')
 
@@ -130,6 +187,26 @@ class TestDroplet(unittest.TestCase):
         self.assertEqual(response['action']['type'], "reboot")
         self.assertEqual(response['action']['resource_id'], 12345)
         self.assertEqual(response['action']['resource_type'], "droplet")
+
+    @responses.activate
+    def test_reboot_action(self):
+        data = self.load_from_file('droplet_actions/reboot.json')
+
+        responses.add(responses.POST, self.actions_url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        response = self.droplet.reboot(return_dict=False)
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.actions_url + "?type=reboot")
+        self.assertEqual(response.id, 54321)
+        self.assertEqual(response.status, "in-progress")
+        self.assertEqual(response.type, "reboot")
+        self.assertEqual(response.resource_id, 12345)
+        self.assertEqual(response.resource_type, "droplet")
+
 
     @responses.activate
     def test_power_cycle(self):
@@ -151,6 +228,25 @@ class TestDroplet(unittest.TestCase):
         self.assertEqual(response['action']['resource_type'], "droplet")
 
     @responses.activate
+    def test_power_cycle_action(self):
+        data = self.load_from_file('droplet_actions/power_cycle.json')
+
+        responses.add(responses.POST, self.actions_url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        response = self.droplet.power_cycle(return_dict=False)
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.actions_url + "?type=power_cycle")
+        self.assertEqual(response.id, 54321)
+        self.assertEqual(response.status, "in-progress")
+        self.assertEqual(response.type, "power_cycle")
+        self.assertEqual(response.resource_id, 12345)
+        self.assertEqual(response.resource_type, "droplet")
+
+    @responses.activate
     def test_reset_root_password(self):
         data = self.load_from_file('droplet_actions/password_reset.json')
 
@@ -168,6 +264,25 @@ class TestDroplet(unittest.TestCase):
         self.assertEqual(response['action']['type'], "password_reset")
         self.assertEqual(response['action']['resource_id'], 12345)
         self.assertEqual(response['action']['resource_type'], "droplet")
+
+    @responses.activate
+    def test_reset_root_password_action(self):
+        data = self.load_from_file('droplet_actions/password_reset.json')
+
+        responses.add(responses.POST, self.actions_url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        response = self.droplet.reset_root_password(return_dict=False)
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.actions_url + "?type=password_reset")
+        self.assertEqual(response.id, 54321)
+        self.assertEqual(response.status, "in-progress")
+        self.assertEqual(response.type, "password_reset")
+        self.assertEqual(response.resource_id, 12345)
+        self.assertEqual(response.resource_type, "droplet")
 
     @responses.activate
     def test_take_snapshot(self):
@@ -189,6 +304,25 @@ class TestDroplet(unittest.TestCase):
         self.assertEqual(response['action']['resource_type'], "droplet")
 
     @responses.activate
+    def test_take_snapshot_action(self):
+        data = self.load_from_file('droplet_actions/snapshot.json')
+
+        responses.add(responses.POST, self.actions_url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        response = self.droplet.take_snapshot("New Snapshot", return_dict=False)
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.actions_url + "?type=snapshot&name=New+Snapshot")
+        self.assertEqual(response.id, 54321)
+        self.assertEqual(response.status, "in-progress")
+        self.assertEqual(response.type, "snapshot")
+        self.assertEqual(response.resource_id, 12345)
+        self.assertEqual(response.resource_type, "droplet")
+
+    @responses.activate
     def test_resize(self):
         data = self.load_from_file('droplet_actions/resize.json')
 
@@ -208,6 +342,25 @@ class TestDroplet(unittest.TestCase):
         self.assertEqual(response['action']['resource_type'], "droplet")
 
     @responses.activate
+    def test_resize_action(self):
+        data = self.load_from_file('droplet_actions/resize.json')
+
+        responses.add(responses.POST, self.actions_url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        response = self.droplet.resize("64gb", False)
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.actions_url + "?type=resize&size=64gb")
+        self.assertEqual(response.id, 54321)
+        self.assertEqual(response.status, "in-progress")
+        self.assertEqual(response.type, "resize")
+        self.assertEqual(response.resource_id, 12345)
+        self.assertEqual(response.resource_type, "droplet")
+
+    @responses.activate
     def test_restore(self):
         data = self.load_from_file('droplet_actions/restore.json')
 
@@ -225,6 +378,25 @@ class TestDroplet(unittest.TestCase):
         self.assertEqual(response['action']['type'], "restore")
         self.assertEqual(response['action']['resource_id'], 12345)
         self.assertEqual(response['action']['resource_type'], "droplet")
+
+    @responses.activate
+    def test_restore_action(self):
+        data = self.load_from_file('droplet_actions/restore.json')
+
+        responses.add(responses.POST, self.actions_url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        response = self.droplet.restore(image_id=78945, return_dict = False)
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.actions_url + "?image=78945&type=restore")
+        self.assertEqual(response.id, 54321)
+        self.assertEqual(response.status, "in-progress")
+        self.assertEqual(response.type, "restore")
+        self.assertEqual(response.resource_id, 12345)
+        self.assertEqual(response.resource_type, "droplet")
 
     @responses.activate
     def test_rebuild_passing_image(self):
@@ -249,6 +421,28 @@ class TestDroplet(unittest.TestCase):
         self.assertEqual(response['action']['resource_type'], "droplet")
 
     @responses.activate
+    def test_rebuild_passing_image_action(self):
+        """
+        Test rebuilding an droplet from a provided image id.
+        """
+        data = self.load_from_file('droplet_actions/rebuild.json')
+
+        responses.add(responses.POST, self.actions_url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        response = self.droplet.rebuild(image_id=78945, return_dict = False)
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.actions_url + "?image=78945&type=rebuild")
+        self.assertEqual(response.id, 54321)
+        self.assertEqual(response.status, "in-progress")
+        self.assertEqual(response.type, "rebuild")
+        self.assertEqual(response.resource_id, 12345)
+        self.assertEqual(response.resource_type, "droplet")
+
+    @responses.activate
     def test_rebuild_not_passing_image(self):
         """
         Test rebuilding an droplet from its original parent image id.
@@ -271,6 +465,28 @@ class TestDroplet(unittest.TestCase):
         self.assertEqual(response['action']['resource_type'], "droplet")
 
     @responses.activate
+    def test_rebuild_not_passing_image_action(self):
+        """
+        Test rebuilding an droplet from its original parent image id.
+        """
+        data = self.load_from_file('droplet_actions/rebuild.json')
+
+        responses.add(responses.POST, self.actions_url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        response = self.droplet.rebuild(return_dict = False)
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.actions_url + "?image=6918990&type=rebuild")
+        self.assertEqual(response.id, 54321)
+        self.assertEqual(response.status, "in-progress")
+        self.assertEqual(response.type, "rebuild")
+        self.assertEqual(response.resource_id, 12345)
+        self.assertEqual(response.resource_type, "droplet")
+
+    @responses.activate
     def test_disable_backups(self):
         data = self.load_from_file('droplet_actions/disable_backups.json')
 
@@ -288,6 +504,25 @@ class TestDroplet(unittest.TestCase):
         self.assertEqual(response['action']['type'], "disable_backups")
         self.assertEqual(response['action']['resource_id'], 12345)
         self.assertEqual(response['action']['resource_type'], "droplet")
+
+    @responses.activate
+    def test_disable_backups_action(self):
+        data = self.load_from_file('droplet_actions/disable_backups.json')
+
+        responses.add(responses.POST, self.actions_url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        response = self.droplet.disable_backups(return_dict=False)
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.actions_url + "?type=disable_backups")
+        self.assertEqual(response.id, 54321)
+        self.assertEqual(response.status, "in-progress")
+        self.assertEqual(response.type, "disable_backups")
+        self.assertEqual(response.resource_id, 12345)
+        self.assertEqual(response.resource_type, "droplet")
 
     @responses.activate
     def test_destroy(self):
@@ -320,6 +555,25 @@ class TestDroplet(unittest.TestCase):
         self.assertEqual(response['action']['resource_type'], "droplet")
 
     @responses.activate
+    def test_rename_action(self):
+        data = self.load_from_file('droplet_actions/rename.json')
+
+        responses.add(responses.POST, self.actions_url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        response = self.droplet.rename(name="New Name", return_dict=False)
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.actions_url + "?type=rename&name=New+Name")
+        self.assertEqual(response.id, 54321)
+        self.assertEqual(response.status, "in-progress")
+        self.assertEqual(response.type, "rename")
+        self.assertEqual(response.resource_id, 12345)
+        self.assertEqual(response.resource_type, "droplet")
+
+    @responses.activate
     def test_enable_private_networking(self):
         data = self.load_from_file('droplet_actions/enable_private_networking.json')
 
@@ -339,6 +593,25 @@ class TestDroplet(unittest.TestCase):
         self.assertEqual(response['action']['resource_type'], "droplet")
 
     @responses.activate
+    def test_enable_private_networking_action(self):
+        data = self.load_from_file('droplet_actions/enable_private_networking.json')
+
+        responses.add(responses.POST, self.actions_url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        response = self.droplet.enable_private_networking(return_dict=False)
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.actions_url + "?type=enable_private_networking")
+        self.assertEqual(response.id, 54321)
+        self.assertEqual(response.status, "in-progress")
+        self.assertEqual(response.type, "enable_private_networking")
+        self.assertEqual(response.resource_id, 12345)
+        self.assertEqual(response.resource_type, "droplet")
+
+    @responses.activate
     def test_enable_ipv6(self):
         data = self.load_from_file('droplet_actions/enable_ipv6.json')
 
@@ -356,6 +629,25 @@ class TestDroplet(unittest.TestCase):
         self.assertEqual(response['action']['type'], "enable_ipv6")
         self.assertEqual(response['action']['resource_id'], 12345)
         self.assertEqual(response['action']['resource_type'], "droplet")
+
+    @responses.activate
+    def test_enable_ipv6_action(self):
+        data = self.load_from_file('droplet_actions/enable_ipv6.json')
+
+        responses.add(responses.POST, self.actions_url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        response = self.droplet.enable_ipv6(return_dict=False)
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.actions_url + "?type=enable_ipv6")
+        self.assertEqual(response.id, 54321)
+        self.assertEqual(response.status, "in-progress")
+        self.assertEqual(response.type, "enable_ipv6")
+        self.assertEqual(response.resource_id, 12345)
+        self.assertEqual(response.resource_type, "droplet")
 
     def test_change_kernel_exception(self):
 
@@ -383,6 +675,26 @@ class TestDroplet(unittest.TestCase):
         self.assertEqual(response['action']['type'], "change_kernel")
         self.assertEqual(response['action']['resource_id'], 12345)
         self.assertEqual(response['action']['resource_type'], "droplet")
+
+    @responses.activate
+    def test_change_kernel_action(self):
+        data = self.load_from_file('droplet_actions/change_kernel.json')
+
+        responses.add(responses.POST, self.actions_url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        response = self.droplet.change_kernel(digitalocean.Kernel(id=123),
+                return_dict=False)
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.actions_url + "?kernel=123&type=change_kernel")
+        self.assertEqual(response.id, 54321)
+        self.assertEqual(response.status, "in-progress")
+        self.assertEqual(response.type, "change_kernel")
+        self.assertEqual(response.resource_id, 12345)
+        self.assertEqual(response.resource_type, "droplet")
 
     @responses.activate
     def test_create_no_keys(self):


### PR DESCRIPTION
Methods in Droplet than perform Droplet actions return dicts. The dicts
represent actions. Some may want these methods to return Actions instead
of raw dictionaries.

An optional paramater of return_dict was added to all methods that
perform Droplet actions. When set to false, an Action object is returned
instead of a dict.

Tests were added for when the Droplet methods return Action.
