### PR TITLE
Allow SSHKey to be specified by fingerprint (Fixes #76)

### DIFF
--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -423,7 +423,7 @@ class Droplet(BaseAPI):
                 match = re.match(regexp_of_fingerprint, ssh_key)
 
                 if match is not None and match.end() == len(ssh_key) - 1:
-                    ssh_keys_id.append(ssh_keys)
+                    ssh_keys_id.append(ssh_key)
 
                 else:
                     key = SSHKey()

--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -403,11 +403,11 @@ class Droplet(BaseAPI):
             return_dict
         )
 
-    def __get_ssh_keys_id(self):
+    def __get_ssh_keys_id_or_fingerprint(self):
         """
-            Check and return a list of SSH key IDs according to DigitalOcean's
-            API. This method is usde to check and create a droplet with the
-            correct SSH keys.
+            Check and return a list of SSH key IDs or fingerprints according
+            to DigitalOcean's API. This method is used to check and create a
+            droplet with the correct SSH keys.
         """
         ssh_keys_id = list()
         for ssh_key in self.ssh_keys:
@@ -418,21 +418,30 @@ class Droplet(BaseAPI):
                 ssh_keys_id.append(ssh_key.id)
 
             elif type(ssh_key) in [str, unicode]:
-                key = SSHKey()
-                key.token = self.token
-                results = key.load_by_pub_key(ssh_key)
+                # ssh_key could either be a fingerprint or a public key
+                regexp_of_fingerprint = '([0-9a-fA-F]{2}:){15}[0-9a-fA-F]'
+                match = re.match(regexp_of_fingerprint, ssh_key)
 
-                if results is None:
-                    key.public_key = ssh_key
-                    key.name = "SSH Key %s" % self.name
-                    key.create()
+                if match is not None and match.end() == len(ssh_key) - 1:
+                    ssh_keys_id.append(ssh_keys)
+
                 else:
-                    key = results
+                    key = SSHKey()
+                    key.token = self.token
+                    results = key.load_by_pub_key(ssh_key)
 
-                ssh_keys_id.append(key.id)
+                    if results is None:
+                        key.public_key = ssh_key
+                        key.name = "SSH Key %s" % self.name
+                        key.create()
+                    else:
+                        key = results
+
+                    ssh_keys_id.append(key.id)
             else:
                 raise BadSSHKeyFormat(
-                    "Droplet.ssh_keys should be a list of IDs or public keys"
+                    "Droplet.ssh_keys should be a list of IDs, public keys"
+                     + " or fingerprints."
                 )
 
         return ssh_keys_id
@@ -456,7 +465,7 @@ class Droplet(BaseAPI):
             "size": self.size_slug,
             "image": self.image,
             "region": self.region,
-            "ssh_keys[]": self.__get_ssh_keys_id(),
+            "ssh_keys[]": self.__get_ssh_keys_id_or_fingerprint(),
         }
 
         if self.backups:

--- a/digitalocean/SSHKey.py
+++ b/digitalocean/SSHKey.py
@@ -21,8 +21,19 @@ class SSHKey(BaseAPI):
         return ssh_key
 
     def load(self):
+        """
+            Load the SSHKey object from DigitalOcean.
+
+            Requires either self.id or self.fingerprint to be set.
+        """
+        identifier = None
+        if self.id is not None:
+            identifier = self.id
+        elif self.fingerprint is not None:
+            identifier = self.fingerprint
+
         data = self.get_data(
-            "account/keys/%s" % self.id,
+            "account/keys/%s" % identifier,
             type="GET"
         )
 


### PR DESCRIPTION
This change modifies __get_ssh_keys_id to return a list containing IDs or fingerprints. The code assumes that fingerprints consist of 16 hexadecimal pairs separated by colons (e.g. 01:23:45:67:89:af:ca:ef:FE:DE:CB:A9:87:65:43:21).

This change also modifies SHHKeys.load. Allowing you to load a SHHKey by fingerprint.

examples:

    d = Droplet(...)
    d.create(ssh_keys=['01:23:45:67:89:ab:cd:ef:FE:DE:CB:A9:87:65:43:21'])

or

    key = SSHKeys(fingerprint='01:23:45:67:89:ab:cd:ef:FE:DE:CB:A9:87:65:43:21')
    key.load()
    d = Droplet(...)
    d.create(ssh_keys=[key])

I have not tested these modifications, but it should be fine to merge since it will not break any existing code (it might introduce buggy new features).