### PR TITLE
Deal with pagination by increasing 'per_page'

### DIFF
--- a/digitalocean/Manager.py
+++ b/digitalocean/Manager.py
@@ -18,11 +18,13 @@ class Manager(BaseAPI):
         """
             Customized version of get_data to perform __check_actions_in_data
         """
-        data = super(Manager, self).get_data(*args, **kwargs)
-
-        params = {}
         if "params" in kwargs:
             params = kwargs['params']
+        else:
+            params = {}
+            kwargs['params'] = params
+        params.update({'per_page': 200})
+        data = super(Manager, self).get_data(*args, **kwargs)
         unpaged_data = self.__deal_with_pagination(args[0], data, params)
 
         return unpaged_data


### PR DESCRIPTION
Each request to the DigitalOcean API has an associated overhead. With
pagination, this overhead is accumulated by following the linked list of
pages. Retrieving large lists becomes slow.

Increasing the "per_page" parameter to the number of elements results in
a maximum of two requests, reducing the total overhead.

Using this method for get_all_images is ten seconds faster for me YMMV.