### PR TITLE
Use JSON payload for POST/PUT calls instead of HTTP query paramaters

### DIFF
--- a/digitalocean/baseapi.py
+++ b/digitalocean/baseapi.py
@@ -41,14 +41,12 @@ class BaseAPI(object):
     def __perform_post(self, url, headers=None, params=None):
         if headers is None: headers = {}
         if params is None: params = {}
-        headers['content-type'] = 'application/json'
-        return requests.post(url, headers=headers, params=params)
+        return requests.post(url, headers=headers, json=params)
 
     def __perform_put(self, url, headers=None, params=None):
         if headers is None: headers = {}
         if params is None: params = {}
-        headers['content-type'] = 'application/json'
-        return requests.put(url, headers=headers, params=params)
+        return requests.put(url, headers=headers, json=params)
 
     def __perform_delete(self, url, headers=None, params=None):
         if headers is None: headers = {}

--- a/digitalocean/baseapi.py
+++ b/digitalocean/baseapi.py
@@ -33,28 +33,38 @@ class BaseAPI(object):
         for attr in kwargs.keys():
             setattr(self, attr, kwargs[attr])
 
-    def __perform_get(self, url, headers=dict(), params=dict()):
+    def __perform_get(self, url, headers=None, params=None):
+        if headers is None: headers = {}
+        if params is None: params = {}
         return requests.get(url, headers=headers, params=params)
 
-    def __perform_post(self, url, headers=dict(), params=dict()):
+    def __perform_post(self, url, headers=None, params=None):
+        if headers is None: headers = {}
+        if params is None: params = {}
         headers['content-type'] = 'application/json'
         return requests.post(url, headers=headers, params=params)
 
-    def __perform_put(self, url, headers=dict(), params=dict()):
+    def __perform_put(self, url, headers=None, params=None):
+        if headers is None: headers = {}
+        if params is None: params = {}
         headers['content-type'] = 'application/json'
         return requests.put(url, headers=headers, params=params)
 
-    def __perform_delete(self, url, headers=dict(), params=dict()):
+    def __perform_delete(self, url, headers=None, params=None):
+        if headers is None: headers = {}
+        if params is None: params = {}
         headers['content-type'] = 'application/x-www-form-urlencoded'
         return requests.delete(url, headers=headers, params=params)
 
-    def __perform_request(self, url, type='GET', params=dict(), headers=dict()):
+    def __perform_request(self, url, type='GET', params=None, headers=None):
         """
             This method will perform the real request,
             in this way we can customize only the "output" of the API call by
             using self.__call_api method.
             This method will return the request object.
         """
+        if headers is None: headers = {}
+        if params is None: params = {}
         if not self.token:
             raise TokenError("No token provied. Please use a valid token")
 


### PR DESCRIPTION
This improves the conversion of Python data into the format expected by the DO API.

In particular I had an issue where boolean values were being rendered as 'True' or 'False' in the query parameters when the DO API specified 'true' or 'false'

This only became a problem for me last week when I noticed my instances were no longer being created with private networking - I realised  that `private_network=True` was no longer being honoured, whereas `private_network=true` still worked. (I suspect that some of the DO API servers have had some change to the JSON library used)
 
By using the requests library native JSON support such conversion issues are handled automatically and we no longer even need to specify `'content-type': 'application/json'` since this is automatically set when we use requests' `json=` parameter.

Also I changed the handling of default values in `baseapi` - I noticed that under some circumstances the `content-type` header was being set to `x-www-form-urlencoded` for _all_ requests, not just `DELETE` - I realised that this was due to the use of dictionaries as default method parameter values - a well-known pitfall in Python.