### PR TITLE
Fix #92

### DIFF
--- a/digitalocean/Domain.py
+++ b/digitalocean/Domain.py
@@ -98,7 +98,7 @@ class Domain(BaseAPI):
 
         for record_data in data['domain_records']:
 
-            record = Record(**record_data)
+            record = Record(domain_name = self.name, **record_data)
             record.token = self.token
             records.append(record)
 


### PR DESCRIPTION
A Domain Record needs it's domain name to destroy itself. This is passed
into the Record when Domain.get_records() is called.