### PR TITLE
Add Action.region_slug

### DIFF
--- a/digitalocean/Action.py
+++ b/digitalocean/Action.py
@@ -13,6 +13,7 @@ class Action(BaseAPI):
         self.resource_id = None
         self.resource_type = None
         self.region = None
+        self.region_slug = None
         # Custom, not provided by the json object.
         self.droplet_id = None
 

--- a/digitalocean/tests/data/actions/create_completed.json
+++ b/digitalocean/tests/data/actions/create_completed.json
@@ -1,6 +1,7 @@
 {
   "action":
     {
+      "region_slug":"nyc3",
       "id":39290099,
       "status":"completed",
       "type":"create",

--- a/digitalocean/tests/data/actions/ipv6_completed.json
+++ b/digitalocean/tests/data/actions/ipv6_completed.json
@@ -1,6 +1,7 @@
 {
   "action":
     {
+      "region_slug":"nyc3",
       "id":39388122,
       "status":"completed",
       "type":"enable_ipv6",

--- a/digitalocean/tests/data/actions/multi.json
+++ b/digitalocean/tests/data/actions/multi.json
@@ -2,6 +2,7 @@
   "actions":
     [
       {
+        "region_slug":"nyc3",
         "id":39388122,
         "status":"completed",
         "type":"enable_ipv6",
@@ -12,6 +13,7 @@
         "region":"nyc3"
       },
       {
+        "region_slug":"nyc3",
         "id":39290099,
         "status":"completed",
         "type":"create",

--- a/digitalocean/tests/test_action.py
+++ b/digitalocean/tests/test_action.py
@@ -1,0 +1,33 @@
+import unittest
+import responses
+import json
+import digitalocean
+
+from .BaseTest import BaseTest
+
+
+class TestAction(BaseTest):
+
+    def setUp(self):
+        super(TestAction, self).setUp()
+        self.action = digitalocean.Action(id=39388122, token=self.token)
+
+    @responses.activate
+    def test_load_directly(self):
+        data = self.load_from_file('actions/ipv6_completed.json')
+
+        responses.add(responses.GET, self.base_url + "actions/39388122",
+                      body=data,
+                      status=200,
+                      content_type='application/json')
+
+        self.action.load_directly()
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.base_url + "actions/39388122")
+        self.assertEqual(self.action.status, "completed")
+        self.assertEqual(self.action.id, 39388122)
+        self.assertEqual(self.action.region_slug, 'nyc3')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds Action.region_slug and the beginning of tests for Actions.

This is in preparation of https://developers.digitalocean.com/documentation/changelog/api-v2/actions-breaking-changes-upgrade-path/

`region` will soon be an embedded object. So `region_slug` has been added for helping transition.