### PR TITLE
added properties for lazy instantiation

### DIFF
--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -556,3 +556,63 @@ class Droplet(BaseAPI):
 
     def __str__(self):
         return "%s %s" % (self.id, self.name)
+
+
+    """
+      Addition:
+        Class properties for lazy instantiation
+
+      Description:
+        Add properties to Droplet class. This allows us to access droplet
+        properties without first making an api call. If there is no data
+        set for an object property, the api will make a call to get the data.
+
+      Example:
+        for snapshot in droplet.snapshots:
+          print( snapshot.name )
+    """
+    @property
+    def events(self):
+      self._events = self.get_events()
+      return self._events
+    
+    @events.setter
+    def events(self, value):
+      self._events = value
+
+    @property
+    def actions(self):
+      self._actions = self.get_actions()
+      return self._actions
+    
+    @actions.setter
+    def actions(self, value):
+      self._actions = value
+
+    @property
+    def action(self):
+      self._action = self.get_action()
+      return self._action
+    
+    @action.setter
+    def action(self, value):
+      self._action = value
+
+    @property
+    def snapshots(self):
+      self._snapshots = self.get_snapshots()
+      return self._snapshots
+    
+    @snapshots.setter
+    def snapshots(self, value):
+      self._snapshots = value
+
+    @property
+    def available_kernels(self):
+      self._available_kernels = self.get_kernel_available()
+      return self._available_kernels
+    
+    @available_kernels.setter
+    def available_kernels(self, value):
+      self._available_kernels = value
+

--- a/digitalocean/Manager.py
+++ b/digitalocean/Manager.py
@@ -201,3 +201,73 @@ class Manager(BaseAPI):
 
     def __str__(self):
         return "%s" % (self.token)
+
+
+    """
+      Addition:
+        Class properties for lazy instantiation
+
+      Description:
+        Add properties to Manager class. This allows us to access manager
+        properties without first making an api call. If there is no data
+        set for an object property, the api will make a call to get the data.
+
+      Example:
+        for droplet in manager.droplets:
+          print( droplet.name )
+    """
+    @property
+    def account(self):
+      self._account = self.get_account()
+      return self._account
+    
+    @account.setter
+    def account(self, value):
+      self._account = value
+
+    @property
+    def droplets(self):
+      self._droplets = self.get_all_droplets()
+      return self._droplets
+    
+    @droplets.setter
+    def droplets(self, value):
+      self._droplets = value
+
+    @property
+    def domains(self):
+      self._domains = self.get_all_domains()
+      return self._domains
+    
+    @domains.setter
+    def domains(self, value):
+      self._domains = value
+
+    @property
+    def regions(self):
+      self._regions = self.get_all_regions()
+      return self._regions
+    
+    @regions.setter
+    def regions(self, value):
+      self._regions = value
+
+    @property
+    def sizes(self):
+      self._sizes = self.get_all_sizes()
+      return self._sizes
+    
+    @sizes.setter
+    def sizes(self, value):
+      self._sizes = value
+
+    @property
+    def images(self):
+      self._images = self.get_all_images()
+      return self._images
+    
+    @images.setter
+    def images(self, value):
+      self._images = value
+
+

--- a/digitalocean/baseapi.py
+++ b/digitalocean/baseapi.py
@@ -115,3 +115,20 @@ class BaseAPI(object):
 
     def __unicode__(self):
         return u"%s" % self.__str__()
+
+    """
+      Addition:
+        This property returns a string of the object properties.
+      Description:
+        Used for a visual representaion to see the object
+        details in the console while testing.
+      Example:
+        print( droplet.details )
+    """
+    @property
+    def details(self):
+      details = ""
+      for key in self.__dict__.keys():
+        details = details+"%s: %s\n" % ( key, self.__dict__.get(key) )
+      self._details = details
+      return self._details


### PR DESCRIPTION
Addition:
Class properties for lazy instantiation

Description:
Add properties to Manager class. This allows us to access manager properties without first making an api call. If there is no data set for an object property, the api will make a call to get the data.

Example:
for droplet in manager.droplets: print( droplet.name )