### PR TITLE
Pass API token to any Action created by Droplet

### DIFF
--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -162,7 +162,7 @@ class Droplet(BaseAPI):
             return action
         else:
             action = action[u'action']
-            return_action = Action()
+            return_action = Action(token=self.token)
             # Loading attributes
             for attr in action.keys():
                 setattr(return_action, attr, action[attr])


### PR DESCRIPTION
When a method in Droplet returns an Action, Action should be given a
copy of the API token. This allows you to call Action's methods without
needing to explicitly pass in an API token.