### PR TITLE
Filter image results using query parameters.

### DIFF
--- a/digitalocean/Manager.py
+++ b/digitalocean/Manager.py
@@ -113,16 +113,29 @@ class Manager(BaseAPI):
             sizes.append(size)
         return sizes
 
-    def get_all_images(self):
+    def get_images(self, private=False, type=None):
         """
             This function returns a list of Image object.
         """
-        data = self.get_data("images/")
+        params = {}
+        if private:
+            params['private'] = 'true'
+        if type:
+            params['type'] = type
+        data = self.get_data("images/", params=params)
         images = list()
         for jsoned in data['images']:
             image = Image(**jsoned)
             image.token = self.token
             images.append(image)
+        return images
+
+    def get_all_images(self):
+        """
+            This function returns a list of Image objects containing all
+            available DigitalOcean images, both public and private.
+        """
+        images = self.get_images()
         return images
 
     def get_image(self, image_id):
@@ -136,13 +149,7 @@ class Manager(BaseAPI):
             This function returns a list of Image objects representing
             private DigitalOcean images (e.g. snapshots and backups).
         """
-        params = {'private': 'true'}
-        data = self.get_data("images/", params=params)
-        images = list()
-        for jsoned in data['images']:
-            image = Image(**jsoned)
-            image.token = self.token
-            images.append(image)
+        images = self.get_images(private=True)
         return images
 
     def get_global_images(self):
@@ -151,13 +158,12 @@ class Manager(BaseAPI):
             public DigitalOcean images (e.g. base distribution images
             and 'One-Click' applications).
         """
-        data = self.get_data("images/")
+        data = self.get_images()
         images = list()
-        for jsoned in data['images']:
-            if jsoned['public']:
-                image = Image(**jsoned)
-                image.token = self.token
-                images.append(image)
+        for i in data:
+            if i.public:
+                i.token = self.token
+                images.append(i)
         return images
 
     def get_distro_images(self):
@@ -165,28 +171,18 @@ class Manager(BaseAPI):
             This function returns a list of Image objects representing
             public base distribution images.
         """
-        params = {'type': 'distribution'}
-        data = self.get_data("images/", params=params)
-        images = list()
-        for jsoned in data['images']:
-            image = Image(**jsoned)
-            image.token = self.token
-            images.append(image)
+        images = self.get_images(type='distribution')
         return images
+
 
     def get_app_images(self):
         """
             This function returns a list of Image objectobjects representing
             public DigitalOcean 'One-Click' application images.
         """
-        params = {'type': 'application'}
-        data = self.get_data("images/", params=params)
-        images = list()
-        for jsoned in data['images']:
-            image = Image(**jsoned)
-            image.token = self.token
-            images.append(image)
+        images = self.get_images(type='application')
         return images
+
 
     def get_all_domains(self):
         """

--- a/digitalocean/Manager.py
+++ b/digitalocean/Manager.py
@@ -133,20 +133,23 @@ class Manager(BaseAPI):
 
     def get_my_images(self):
         """
-            This function returns a list of Image object.
+            This function returns a list of Image objects representing
+            private DigitalOcean images (e.g. snapshots and backups).
         """
-        data = self.get_data("images/")
+        params = {'private': 'true'}
+        data = self.get_data("images/", params=params)
         images = list()
         for jsoned in data['images']:
-            if not jsoned['public']:
-                image = Image(**jsoned)
-                image.token = self.token
-                images.append(image)
+            image = Image(**jsoned)
+            image.token = self.token
+            images.append(image)
         return images
 
     def get_global_images(self):
         """
-            This function returns a list of Image object.
+            This function returns a list of Image objects representing
+            public DigitalOcean images (e.g. base distribution images
+            and 'One-Click' applications).
         """
         data = self.get_data("images/")
         images = list()
@@ -155,6 +158,34 @@ class Manager(BaseAPI):
                 image = Image(**jsoned)
                 image.token = self.token
                 images.append(image)
+        return images
+
+    def get_distro_images(self):
+        """
+            This function returns a list of Image objects representing
+            public base distribution images.
+        """
+        params = {'type': 'distribution'}
+        data = self.get_data("images/", params=params)
+        images = list()
+        for jsoned in data['images']:
+            image = Image(**jsoned)
+            image.token = self.token
+            images.append(image)
+        return images
+
+    def get_app_images(self):
+        """
+            This function returns a list of Image objectobjects representing
+            public DigitalOcean 'One-Click' application images.
+        """
+        params = {'type': 'application'}
+        data = self.get_data("images/", params=params)
+        images = list()
+        for jsoned in data['images']:
+            image = Image(**jsoned)
+            image.token = self.token
+            images.append(image)
         return images
 
     def get_all_domains(self):

--- a/digitalocean/tests/data/images/app.json
+++ b/digitalocean/tests/data/images/app.json
@@ -1,0 +1,49 @@
+{
+  "images": [
+  {
+    "id": 11146864,
+    "name": "MEAN on 14.04",
+    "distribution": "Ubuntu",
+    "slug": "mean",
+    "public": true,
+    "regions": [
+      "nyc1",
+      "ams1",
+      "sfo1",
+      "nyc2",
+      "ams2",
+      "sgp1",
+      "lon1",
+      "nyc3",
+      "ams3"
+    ],
+    "created_at": "2015-03-24T17:10:43Z",
+    "min_disk_size": 20,
+    "type": "snapshot"
+  },
+  {
+    "id": 11162594,
+    "name": "Dokku v0.3.16 on 14.04",
+    "distribution": "Ubuntu",
+    "slug": "dokku",
+    "public": true,
+    "regions": [
+      "nyc1",
+      "ams1",
+      "sfo1",
+      "nyc2",
+      "ams2",
+      "sgp1",
+      "lon1",
+      "nyc3",
+      "ams3"
+    ],
+    "created_at": "2015-03-25T19:00:05Z",
+    "min_disk_size": 20,
+    "type": "snapshot"
+  }
+  ],
+  "meta": {
+    "total": 2
+  }
+}

--- a/digitalocean/tests/data/images/distro.json
+++ b/digitalocean/tests/data/images/distro.json
@@ -1,0 +1,29 @@
+{
+  "images": [
+    {
+      "id": 119192817,
+      "name": "14.04 x64",
+      "distribution": "Ubuntu",
+      "slug": "ubuntu-14-04-x64",
+      "public": true,
+      "regions": [
+        "nyc1"
+      ],
+      "created_at": "2014-07-29T14:35:40Z"
+    },
+    {
+      "id": 449676376,
+      "name": "14.04 x32",
+      "distribution": "Ubuntu",
+      "slug": "ubuntu-14-04-x32",
+      "public": true,
+      "regions": [
+        "nyc1"
+      ],
+      "created_at": "2014-07-29T14:35:40Z"
+    }
+  ],
+  "meta": {
+    "total": 2
+  }
+}

--- a/digitalocean/tests/data/images/private.json
+++ b/digitalocean/tests/data/images/private.json
@@ -1,0 +1,19 @@
+{
+  "images": [
+    {
+      "id": 449676856,
+      "name": "My Snapshot",
+      "distribution": "Ubuntu",
+      "slug": "",
+      "public": false,
+      "regions": [
+        "nyc1",
+        "nyc3"
+      ],
+      "created_at": "2014-08-18T16:35:40Z"
+    }
+  ],
+  "meta": {
+    "total": 1
+  }
+}

--- a/digitalocean/tests/test_manager.py
+++ b/digitalocean/tests/test_manager.py
@@ -175,7 +175,7 @@ class TestManager(BaseTest):
 
     @responses.activate
     def test_get_my_images(self):
-        data = self.load_from_file('images/all.json')
+        data = self.load_from_file('images/private.json')
 
         url = self.base_url + 'images/'
         responses.add(responses.GET, url,
@@ -195,6 +195,54 @@ class TestManager(BaseTest):
         self.assertEqual(image.distribution, 'Ubuntu')
         self.assertEqual(image.regions, ['nyc1', 'nyc3'])
         self.assertEqual(image.created_at, "2014-08-18T16:35:40Z")
+        self.assert_url_query_equal(responses.calls[0].request.url,
+                                    'https://api.digitalocean.com/v2/images/?private=true&per_page=200')
+
+    @responses.activate
+    def test_get_distro_images(self):
+        data = self.load_from_file('images/distro.json')
+
+        url = self.base_url + 'images/'
+        responses.add(responses.GET, url,
+                      body=data,
+                      status=200,
+                      content_type='application/json')
+
+        distro_images = self.manager.get_distro_images()
+        self.assertEqual(len(distro_images), 2)
+
+        image = distro_images[0]
+        self.assertEqual(image.token, self.token)
+        self.assertEqual(image.id, 119192817)
+        self.assertEqual(image.name, '14.04 x64')
+        self.assertTrue(image.public)
+        self.assertEqual(image.slug, "ubuntu-14-04-x64")
+        self.assertEqual(image.distribution, 'Ubuntu')
+        self.assert_url_query_equal(responses.calls[0].request.url,
+                                    'https://api.digitalocean.com/v2/images/?type=distribution&per_page=200')
+
+    @responses.activate
+    def test_get_app_images(self):
+        data = self.load_from_file('images/app.json')
+
+        url = self.base_url + 'images/'
+        responses.add(responses.GET, url,
+                      body=data,
+                      status=200,
+                      content_type='application/json')
+
+        app_images = self.manager.get_app_images()
+        self.assertEqual(len(app_images), 2)
+
+        image = app_images[0]
+        self.assertEqual(image.token, self.token)
+        self.assertEqual(image.id, 11146864)
+        self.assertEqual(image.name, 'MEAN on 14.04')
+        self.assertTrue(image.public)
+        self.assertEqual(image.slug, "mean")
+        self.assertEqual(image.distribution, 'Ubuntu')
+        self.assert_url_query_equal(responses.calls[0].request.url,
+                                    'https://api.digitalocean.com/v2/images/?type=application&per_page=200')
 
     @responses.activate
     def test_get_all_sshkeys(self):


### PR DESCRIPTION
Awhile back, the API added the ability to filter on private images. We should use this instead of doing the filtering locally.
https://developers.digitalocean.com/documentation/changelog/api-v2/private-images-endpoint/

While we're at it, the API also added support for filter on application and distribution images:

https://developers.digitalocean.com/documentation/changelog/api-v2/add-image-filtering/