### PR TITLE
Allow enabling Droplet backups after creation.

### DIFF
--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -321,11 +321,17 @@ class Droplet(BaseAPI):
             return_dict
         )
 
-    def enable_backups(self):
+    def enable_backups(self, return_dict=True):
         """
-            Enable automatic backups (Not yet implemented in APIv2)
+            Enable automatic backups
+
+            Optional Args:
+                return_dict - bool : Return a dict when True (default),
+                    otherwise return an Action.
+
+            Returns dict or Action
         """
-        print("Not yet implemented in APIv2")
+        return self._perform_action({'type': 'enable_backups'}, return_dict)
 
     def disable_backups(self, return_dict=True):
         """

--- a/digitalocean/tests/data/droplet_actions/enable_backups.json
+++ b/digitalocean/tests/data/droplet_actions/enable_backups.json
@@ -1,0 +1,13 @@
+{
+  "action":
+    {
+      "id":54321,
+      "status":"in-progress",
+      "type":"enable_backups",
+      "started_at":"2014-12-21T02:19:17Z",
+      "completed_at":null,
+      "resource_id":12345,
+      "resource_type":"droplet",
+      "region":"nyc3"
+    }
+}

--- a/digitalocean/tests/test_droplet.py
+++ b/digitalocean/tests/test_droplet.py
@@ -527,6 +527,27 @@ class TestDroplet(BaseTest):
         self.assertEqual(response.resource_type, "droplet")
 
     @responses.activate
+    def test_enable_backups(self):
+        data = self.load_from_file('droplet_actions/enable_backups.json')
+
+        responses.add(responses.POST, self.actions_url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        response = self.droplet.enable_backups()
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.actions_url)
+        self.assertEqual(json.loads(responses.calls[0].request.body),
+                         {"type": "enable_backups"})
+        self.assertEqual(response['action']['id'], 54321)
+        self.assertEqual(response['action']['status'], "in-progress")
+        self.assertEqual(response['action']['type'], "enable_backups")
+        self.assertEqual(response['action']['resource_id'], 12345)
+        self.assertEqual(response['action']['resource_type'], "droplet")
+
+    @responses.activate
     def test_disable_backups(self):
         data = self.load_from_file('droplet_actions/disable_backups.json')
 


### PR DESCRIPTION
https://developers.digitalocean.com/documentation/changelog/api-v2/add-enable-backups/