### PR TITLE
Add Image.size_gigabytes and tests for Image.

### DIFF
--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -51,8 +51,6 @@ class Droplet(BaseAPI):
         action_ids: [int] - list of ids of actions
         features: [str] - list of enabled features. e.g.
                   [u'private_networking', u'virtio']
-        min_size: str - minumum size of droplet that can bew created from a
-                   snapshot of this droplet
         image: dict - details of image used to create this droplet
         ip_address: str - public ip addresses
         private_ip_address: str - private ip address

--- a/digitalocean/Image.py
+++ b/digitalocean/Image.py
@@ -8,10 +8,11 @@ class Image(BaseAPI):
         self.name = None
         self.distribution = None
         self.slug = None
-        self.min_size = None
+        self.min_disk_size = None
         self.public = None
         self.regions = []
         self.created_at = None
+        self.size_gigabytes = None
 
         super(Image, self).__init__(*args, **kwargs)
 

--- a/digitalocean/tests/data/images/all.json
+++ b/digitalocean/tests/data/images/all.json
@@ -9,7 +9,9 @@
       "regions": [
         "nyc1"
       ],
-      "created_at": "2014-07-29T14:35:40Z"
+      "created_at": "2014-07-29T14:35:40Z",
+      "min_disk_size": 20,
+      "size_gigabytes": 1.34
     },
     {
       "id": 449676376,
@@ -20,7 +22,9 @@
       "regions": [
         "nyc1"
       ],
-      "created_at": "2014-07-29T14:35:40Z"
+      "created_at": "2014-07-29T14:35:40Z",
+      "min_disk_size": 20,
+      "size_gigabytes": 1.48
     },
     {
       "id": 449676856,
@@ -32,7 +36,9 @@
         "nyc1",
         "nyc3"
       ],
-      "created_at": "2014-08-18T16:35:40Z"
+      "created_at": "2014-08-18T16:35:40Z",
+      "min_disk_size": 20,
+      "size_gigabytes": 2.34
     }
   ],
   "meta": {

--- a/digitalocean/tests/data/images/app.json
+++ b/digitalocean/tests/data/images/app.json
@@ -19,7 +19,8 @@
     ],
     "created_at": "2015-03-24T17:10:43Z",
     "min_disk_size": 20,
-    "type": "snapshot"
+    "type": "snapshot",
+    "size_gigabytes": 1.36
   },
   {
     "id": 11162594,
@@ -40,7 +41,8 @@
     ],
     "created_at": "2015-03-25T19:00:05Z",
     "min_disk_size": 20,
-    "type": "snapshot"
+    "type": "snapshot",
+    "size_gigabytes": 1.34
   }
   ],
   "meta": {

--- a/digitalocean/tests/data/images/distro.json
+++ b/digitalocean/tests/data/images/distro.json
@@ -9,7 +9,9 @@
       "regions": [
         "nyc1"
       ],
-      "created_at": "2014-07-29T14:35:40Z"
+      "created_at": "2014-07-29T14:35:40Z",
+      "min_disk_size": 20,
+      "size_gigabytes": 1.34
     },
     {
       "id": 449676376,
@@ -20,7 +22,9 @@
       "regions": [
         "nyc1"
       ],
-      "created_at": "2014-07-29T14:35:40Z"
+      "created_at": "2014-07-29T14:35:40Z",
+      "min_disk_size": 20,
+      "size_gigabytes": 1.38
     }
   ],
   "meta": {

--- a/digitalocean/tests/data/images/rename.json
+++ b/digitalocean/tests/data/images/rename.json
@@ -1,8 +1,8 @@
 {
-  "images": [
+  "image":
     {
       "id": 449676856,
-      "name": "My Snapshot",
+      "name": "Descriptive name",
       "distribution": "Ubuntu",
       "slug": "",
       "public": false,
@@ -11,10 +11,7 @@
         "nyc3"
       ],
       "created_at": "2014-08-18T16:35:40Z",
-      "size_gigabytes": 1.34
+      "min_disk_size": 20,
+      "size_gigabytes": 2.34
     }
-  ],
-  "meta": {
-    "total": 1
-  }
 }

--- a/digitalocean/tests/data/images/single.json
+++ b/digitalocean/tests/data/images/single.json
@@ -1,5 +1,5 @@
 {
-  "images": [
+  "image":
     {
       "id": 449676856,
       "name": "My Snapshot",
@@ -11,10 +11,7 @@
         "nyc3"
       ],
       "created_at": "2014-08-18T16:35:40Z",
-      "size_gigabytes": 1.34
+      "min_disk_size": 20,
+      "size_gigabytes": 2.34
     }
-  ],
-  "meta": {
-    "total": 1
-  }
 }

--- a/digitalocean/tests/data/images/transfer.json
+++ b/digitalocean/tests/data/images/transfer.json
@@ -1,0 +1,34 @@
+{
+  "action": {
+    "id": 68212728,
+    "status": "in-progress",
+    "type": "transfer",
+    "started_at": "2015-10-15T17:45:44Z",
+    "completed_at": null,
+    "resource_id": 449676856,
+    "resource_type": "image",
+    "region": {
+      "name": "New York 3",
+      "slug": "nyc3",
+      "sizes": [
+        "512mb",
+        "1gb",
+        "2gb",
+        "4gb",
+        "8gb",
+        "16gb",
+        "32gb",
+        "48gb",
+        "64gb"
+      ],
+      "features": [
+        "private_networking",
+        "backups",
+        "ipv6",
+        "metadata"
+      ],
+      "available": true
+    },
+    "region_slug": "nyc3"
+  }
+}

--- a/digitalocean/tests/test_image.py
+++ b/digitalocean/tests/test_image.py
@@ -1,0 +1,85 @@
+import unittest
+import responses
+import digitalocean
+
+from .BaseTest import BaseTest
+
+
+class TestImage(BaseTest):
+
+    def setUp(self):
+        super(TestImage, self).setUp()
+        self.image = digitalocean.Image(id=449676856, token=self.token)
+
+    @responses.activate
+    def test_load(self):
+        data = self.load_from_file('images/single.json')
+
+        responses.add(responses.GET,
+                      '{}images/{}'.format(self.base_url, self.image.id),
+                      body=data,
+                      status=200,
+                      content_type='application/json')
+
+        self.image.load()
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.base_url + 'images/449676856')
+        self.assertEqual(self.image.id, 449676856)
+        self.assertEqual(self.image.name, 'My Snapshot')
+        self.assertEqual(self.image.distribution, 'Ubuntu')
+        self.assertEqual(self.image.public, False)
+        self.assertEqual(self.image.created_at, "2014-08-18T16:35:40Z")
+        self.assertEqual(self.image.size_gigabytes, 2.34)
+        self.assertEqual(self.image.min_disk_size, 20)
+
+    @responses.activate
+    def test_destroy(self):
+        responses.add(responses.DELETE,
+                      '{}images/{}/'.format(self.base_url, self.image.id),
+                      status=204,
+                      content_type='application/json')
+
+        self.image.destroy()
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.base_url + 'images/449676856/')
+
+    @responses.activate
+    def test_transfer(self):
+        data = self.load_from_file('images/transfer.json')
+
+        responses.add(responses.POST,
+                      '{}images/{}/actions/'.format(
+                        self.base_url, self.image.id),
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        res = self.image.transfer(new_region_slug='lon1')
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.base_url + 'images/449676856/actions/')
+        self.assertEqual(res['action']['type'], 'transfer')
+        self.assertEqual(res['action']['status'], 'in-progress')
+        self.assertEqual(res['action']['id'], 68212728)
+
+    @responses.activate
+    def test_rename(self):
+        data = self.load_from_file('images/rename.json')
+
+        responses.add(responses.PUT,
+                      '{}images/{}'.format(self.base_url, self.image.id),
+                      body=data,
+                      status=200,
+                      content_type='application/json')
+
+        res = self.image.rename(new_name='Descriptive name')
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.base_url + 'images/449676856')
+        self.assertEqual(res['image']['name'], 'Descriptive name')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
A new `size_gigabytes` attribute [has been added ](https://developers.digitalocean.com/documentation/changelog/api-v2/add-size_gigabytes-to-images/) to Images with the actual on disk size of the Image. This PR adds that. I also went ahead and added some tests while I was at it.

This also changes `min_size` to `min_disk_size` to reflect what the API actually returns. I'm not certain, but IIRC that change was done back when APIv2 was still in beta, but it looks like it was never updated here. Just noticed it while working on this.