### PR TITLE
fix: invalid json response handling

### DIFF
--- a/digitalocean/baseapi.py
+++ b/digitalocean/baseapi.py
@@ -105,7 +105,7 @@ class BaseAPI(object):
             data = req.json()
         except ValueError as e:
             raise JSONReadError(
-                'Read failed from DigitalOcean: %s' % e.message
+                'Read failed from DigitalOcean: %s' % str(e)
             )
 
         if not req.ok:


### PR DESCRIPTION
Before:

  AttributeError: 'JSONDecodeError' object has no attribute 'message'

After:

  digitalocean.baseapi.JSONReadError: Read failed from DigitalOcean: Expecting value: line 1 column 1 (char 0)