### PR TITLE
Create multiple droplets

### DIFF
--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -116,6 +116,11 @@ class Droplet(BaseAPI):
             "private_networking": bool(kwargs.get("private_networking")),
         }
 
+        if kwargs.get("ssh_keys"):
+            data["ssh_keys"] = Droplet.__get_ssh_keys_id_or_fingerprint(
+                    kwargs["ssh_keys"], kwargs.get("token"),
+                    kwargs["names"][0])
+
         if kwargs.get("user_data"):
             data["user_data"] = kwargs["user_data"]
 
@@ -126,7 +131,7 @@ class Droplet(BaseAPI):
         if data:
             action_ids = [data["links"]["actions"][0]["id"]]
             for droplet_json in data["droplets"]:
-                droplet_json['token'] = kwargs["token"]
+                droplet_json["token"] = kwargs["token"]
                 droplet = Droplet(**droplet_json)
                 droplet.action_ids = action_ids
                 droplets.append(droplet)
@@ -460,14 +465,15 @@ class Droplet(BaseAPI):
             return_dict
         )
 
-    def __get_ssh_keys_id_or_fingerprint(self):
+    @classmethod
+    def __get_ssh_keys_id_or_fingerprint(ssh_keys, token, name):
         """
             Check and return a list of SSH key IDs or fingerprints according
             to DigitalOcean's API. This method is used to check and create a
             droplet with the correct SSH keys.
         """
         ssh_keys_id = list()
-        for ssh_key in self.ssh_keys:
+        for ssh_key in ssh_keys:
             if type(ssh_key) in [int, type(2 ** 64)]:
                 ssh_keys_id.append(int(ssh_key))
 
@@ -488,12 +494,12 @@ class Droplet(BaseAPI):
 
                 else:
                     key = SSHKey()
-                    key.token = self.token
+                    key.token = token
                     results = key.load_by_pub_key(ssh_key)
 
                     if results is None:
                         key.public_key = ssh_key
-                        key.name = "SSH Key %s" % self.name
+                        key.name = "SSH Key %s" % name
                         key.create()
                     else:
                         key = results
@@ -521,12 +527,16 @@ class Droplet(BaseAPI):
         if not self.size_slug and self.size:
             self.size_slug = self.size
 
+        ssh_keys_id = Droplet.__get_ssh_keys_id_or_fingerprint(self.ssh_keys,
+                                                               self.token,
+                                                               self.name)
+
         data = {
             "name": self.name,
             "size": self.size_slug,
             "image": self.image,
             "region": self.region,
-            "ssh_keys": self.__get_ssh_keys_id_or_fingerprint(),
+            "ssh_keys": ssh_keys_id,
             "backups": bool(self.backups),
             "ipv6": bool(self.ipv6),
             "private_networking": bool(self.private_networking),

--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -104,7 +104,6 @@ class Droplet(BaseAPI):
 
     @classmethod
     def create_multiple(*args, **kwargs):
-        print(kwargs)
         api = BaseAPI(token=kwargs.get("token"))
 
         data = {

--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -465,7 +465,7 @@ class Droplet(BaseAPI):
             return_dict
         )
 
-    @classmethod
+    @staticmethod
     def __get_ssh_keys_id_or_fingerprint(ssh_keys, token, name):
         """
             Check and return a list of SSH key IDs or fingerprints according

--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -103,7 +103,8 @@ class Droplet(BaseAPI):
         return droplet
 
     @classmethod
-    def create_multiple(**kwargs):
+    def create_multiple(*args, **kwargs):
+        print(kwargs)
         api = BaseAPI(token=kwargs.get("token"))
 
         data = {
@@ -126,7 +127,8 @@ class Droplet(BaseAPI):
         if data:
             action_ids = [data["links"]["actions"][0]["id"]]
             for droplet_json in data["droplets"]:
-                droplet = Droplet(droplet_json)
+                droplet_json['token'] = kwargs["token"]
+                droplet = Droplet(**droplet_json)
                 droplet.action_ids = action_ids
                 droplets.append(droplet)
 

--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -102,6 +102,36 @@ class Droplet(BaseAPI):
         droplet.load()
         return droplet
 
+    @classmethod
+    def create_multiple(**kwargs):
+        api = BaseAPI(token=kwargs.get("token"))
+
+        data = {
+            "names": kwargs.get("names"),
+            "size": kwargs.get("size_slug") or kwargs.get("size"),
+            "image": kwargs.get("image"),
+            "region": kwargs.get("region"),
+            "backups": bool(kwargs.get("backups")),
+            "ipv6": bool(kwargs.get("ipv6")),
+            "private_networking": bool(kwargs.get("private_networking")),
+        }
+
+        if kwargs.get("user_data"):
+            data["user_data"] = kwargs["user_data"]
+
+        droplets = []
+
+        data = api.get_data("droplets", type=POST, params=data)
+
+        if data:
+            action_ids = [data["links"]["actions"][0]["id"]]
+            for droplet_json in data["droplets"]:
+                droplet = Droplet(droplet_json)
+                droplet.action_ids = action_ids
+                droplets.append(droplet)
+
+        return droplets
+
     def __check_actions_in_data(self, data):
         # reloading actions if actions is provided.
         if u"actions" in data:

--- a/digitalocean/tests/data/droplet_actions/create_multiple.json
+++ b/digitalocean/tests/data/droplet_actions/create_multiple.json
@@ -1,0 +1,76 @@
+{
+  "droplets": [{
+    "id": 3164494,
+    "name": "example.com",
+    "memory": 512,
+    "vcpus": 1,
+    "disk": 20,
+    "locked": true,
+    "status": "new",
+    "kernel": {
+      "id": 2233,
+      "name": "Ubuntu 14.04 x64 vmlinuz-3.13.0-37-generic",
+      "version": "3.13.0-37-generic"
+    },
+    "created_at": "2014-11-14T16:36:31Z",
+    "features": [
+      "virtio",
+      "backups",
+      "ipv6"
+    ],
+    "backup_ids": [
+
+    ],
+    "snapshot_ids": [
+
+    ],
+    "image": {
+    },
+    "size_slug": "512mb",
+    "networks": {
+    },
+    "region": {
+    }
+  }, {
+    "id": 3164495,
+    "name": "example2.com",
+    "memory": 512,
+    "vcpus": 1,
+    "disk": 20,
+    "locked": true,
+    "status": "new",
+    "kernel": {
+      "id": 2233,
+      "name": "Ubuntu 14.04 x64 vmlinuz-3.13.0-37-generic",
+      "version": "3.13.0-37-generic"
+    },
+    "created_at": "2014-11-14T16:36:31Z",
+    "features": [
+      "virtio",
+      "backups",
+      "ipv6"
+    ],
+    "backup_ids": [
+
+    ],
+    "snapshot_ids": [
+
+    ],
+    "image": {
+    },
+    "size_slug": "512mb",
+    "networks": {
+    },
+    "region": {
+    }
+  }],
+  "links": {
+    "actions": [
+      {
+        "id": 36805096,
+        "rel": "create",
+        "href": "https://api.digitalocean.com/v2/actions/36805096"
+      }
+    ]
+  }
+}

--- a/digitalocean/tests/test_droplet.py
+++ b/digitalocean/tests/test_droplet.py
@@ -813,6 +813,43 @@ class TestDroplet(BaseTest):
         self.assertEqual(droplet.action_ids, [36805096])
 
     @responses.activate
+    def test_create_multiple_no_keys(self):
+        data = self.load_from_file('droplet_actions/create_multiple.json')
+
+        responses.add(responses.POST, self.base_url + "droplets",
+                      body=data,
+                      status=202,
+                      content_type='application/json')
+
+
+        droplets = digitalocean.Droplet.create_multiple(names=["example.com",
+                                                               "example2.com"],
+                                                        size_slug="512mb",
+                                                        image="ubuntu-14-04-x64",
+                                                        region="nyc3",
+                                                        backups=True,
+                                                        ipv6=True,
+                                                        private_networking=True,
+                                                        user_data="Some user data.",
+                                                        token=self.token)
+        self.assert_url_query_equal(responses.calls[0].request.url,
+                                    self.base_url + "droplets")
+        self.assertEqual(len(droplets), 2)
+        self.assertEqual(droplets[0].id, 3164494)
+        self.assertEqual(droplets[1].id, 3164495)
+        self.assertEqual(droplets[0].action_ids, [36805096])
+        self.assertEqual(droplets[1].action_ids, [36805096])
+
+        self.maxDiff = None
+        self.assertEqual(
+            json.loads(responses.calls[0].request.body),
+            {u"names": [u"example.com", u"example2.com"], u"region": u"nyc3",
+             u"user_data": u"Some user data.", u"ipv6": True,
+             u"private_networking": True, u"backups": True,
+             u"image": u"ubuntu-14-04-x64", u"size": u"512mb"})
+
+
+    @responses.activate
     def test_get_actions(self):
         data = self.load_from_file('actions/multi.json')
         create = self.load_from_file('actions/create_completed.json')


### PR DESCRIPTION
Initial support for creating multiple droplets with a single API call. The only thing that is missing is the ability to specify SSH keys.