### PR TITLE
SSHKeys fixes + minor changes to docker for testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+*.pyc
+*__pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ python:
   - "2.7"
   - "3.4"
 install: "pip install -U -r requirements.txt --use-mirrors"
-script: py.test
+script: python -m pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ WORKDIR /root/python-digitalocean
 RUN pip2 install -U -r requirements.txt
 RUN pip3 install -U -r requirements.txt
 
-CMD py.test-2.7 ; py.test-3.4
+CMD python2 -m pytest ; python3 -m pytest

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Use [pytest](http://pytest.org/) to perform testing. It is recommended to use a 
 
 To run all the tests manually use py.test command:
 
-    $ py.test
+    $ python -m pytest
 
 
 ## Links

--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ for action in actions:
     print action.status
 ```
 
+### Creating a new droplet with all your SSH keys
+```python
+manager = digitalocean.Manager(token="secretspecialuniquesnowflake")
+keys = manager.get_all_sshkeys()
+
+droplet = digitalocean.Droplet(token="secretspecialuniquesnowflake",
+                               name='DropletWithSSHKeys',
+                               region='ams3', # Amster
+                               image='ubuntu-14-04-x64', # Ubuntu 14.04 x64
+                               size_slug='512mb',  # 512MB
+                               ssh_keys=keys, #Automatic conversion
+                               backups=False)
+droplet.create()
+```
+
 ## Testing
 
 ### Test using Docker

--- a/digitalocean/SSHKey.py
+++ b/digitalocean/SSHKey.py
@@ -27,7 +27,7 @@ class SSHKey(BaseAPI):
             Requires either self.id or self.fingerprint to be set.
         """
         identifier = None
-        if self.id is not None:
+        if self.id:
             identifier = self.id
         elif self.fingerprint is not None:
             identifier = self.fingerprint


### PR DESCRIPTION
This pull request will:

- Add an example for using the SSH keys #144 
- Fix the SSH Import problem caused by a wrong type #138 
- Update the tests in docker/Travis running pytest as a module (minor change).
- Ignore byte code and pycache files when building with docker for testing.