### PR TITLE
Use urljoin() unconditionally

### DIFF
--- a/digitalocean/Metadata.py
+++ b/digitalocean/Metadata.py
@@ -25,8 +25,7 @@ class Metadata(BaseAPI):
             Customized version of get_data to directly get the data without
             using the authentication method.
         """
-        if "https" not in url:
-            url = urljoin(self.end_point, url)
+        url = urljoin(self.end_point, url)
 
         response = requests.get(url, headers=headers, params=params)
 

--- a/digitalocean/baseapi.py
+++ b/digitalocean/baseapi.py
@@ -59,8 +59,7 @@ class BaseAPI(object):
         if not self.token:
             raise TokenError("No token provided. Please use a valid token")
 
-        if "https" not in url:
-            url = urljoin(self.end_point, url)
+        url = urljoin(self.end_point, url)
 
         # lookup table to find out the apropriate requests method,
         # headers and payload type (json or query parameters)


### PR DESCRIPTION
The condition
```python
if "https" not in url:
```
was meant to check if this is a full URL, but:
- it gives wrong answer for `http://` URLs;
- it gives wrong answer for relative URLs that contain string `https` in the path.

If `urljoin()` is given a full URL, it returns it unchanged, so the condition is not necessary and can be removed.