### PR TITLE
Don't pass --use-mirrors to pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: python
 python:
   - "2.7"
   - "3.4"
-install: "pip install -U -r requirements.txt --use-mirrors"
+install: "pip install -U -r requirements.txt"
 script: python -m pytest


### PR DESCRIPTION
The `--use-mirrors` option was removed in pip 7.0.0.

This reverts commit f064571fecfd86a31f7d323206c4f453537b7056.