### PR TITLE
Catch only ImportError in conditional imports

### DIFF
--- a/digitalocean/Manager.py
+++ b/digitalocean/Manager.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 try:
     from urlparse import urlparse, parse_qs
-except:
+except ImportError:
     from urllib.parse import urlparse, parse_qs
 
 from .baseapi import BaseAPI

--- a/digitalocean/Metadata.py
+++ b/digitalocean/Metadata.py
@@ -2,7 +2,7 @@
 import requests
 try:
     from urlparse import urljoin
-except:
+except ImportError:
     from urllib.parse import urljoin
 
 from .baseapi import BaseAPI

--- a/digitalocean/baseapi.py
+++ b/digitalocean/baseapi.py
@@ -4,7 +4,7 @@ import logging
 import requests
 try:
     from urlparse import urljoin
-except:
+except ImportError:
     from urllib.parse import urljoin
 
 


### PR DESCRIPTION
Bare `except:` catches all exceptions, including exceptions that the programmer never expected to happen, possibly hiding programming errors, or ignoring `KeyboardInterrupt` triggered by user's Ctrl+C.

This bug was found using [pydiatra](https://github.com/jwilk/pydiatra).