### PR TITLE
Request timeouts

### DIFF
--- a/digitalocean/Metadata.py
+++ b/digitalocean/Metadata.py
@@ -27,8 +27,8 @@ class Metadata(BaseAPI):
         """
         url = urljoin(self.end_point, url)
 
-        timeout = self.extract_timeout(params)
-        response = requests.get(url, headers=headers, params=params, timeout=timeout)
+        response = requests.get(url, headers=headers, params=params,
+                                timeout=self.get_timeout())
 
         if render_json:
             return response.json()

--- a/digitalocean/Metadata.py
+++ b/digitalocean/Metadata.py
@@ -27,7 +27,8 @@ class Metadata(BaseAPI):
         """
         url = urljoin(self.end_point, url)
 
-        response = requests.get(url, headers=headers, params=params)
+        timeout = self.extract_timeout(params)
+        response = requests.get(url, headers=headers, params=params, timeout=timeout)
 
         if render_json:
             return response.json()

--- a/digitalocean/baseapi.py
+++ b/digitalocean/baseapi.py
@@ -103,7 +103,15 @@ class BaseAPI(object):
             To set a timeout, use the REQUEST_TIMEOUT_ENV_VAR environment
             variable.
         """
-        return os.environ.get(REQUEST_TIMEOUT_ENV_VAR)
+        timeout_str = os.environ.get(REQUEST_TIMEOUT_ENV_VAR)
+        if timeout_str:
+            try:
+                return float(timeout_str)
+            except:
+                self._log.error('Failed parsing the request read timeout of '
+                                '"%s". Please use a valid float number!' %
+                                        timeout_str)
+        return None
 
     def get_data(self, url, type=GET, params=None):
         """
@@ -120,7 +128,7 @@ class BaseAPI(object):
 
         if req.status_code == 404:
             raise NotFoundError()
-            
+
         try:
             data = req.json()
         except ValueError as e:


### PR DESCRIPTION
The requests library expects a valid float for a timeout value. We get the value as an environment variable, but we don't parse it from string to float. Thus the requests library crashes.