### PR TITLE
Remove Tag.update(). Closes: #194

### DIFF
--- a/digitalocean/Tag.py
+++ b/digitalocean/Tag.py
@@ -43,13 +43,6 @@ class Tag(BaseAPI):
             self.resources = output['tag']['resources']
 
 
-    def update_tag(self, name):
-        query = {"name": name}
-        updated = self.get_data("tags/%s" % self.name, type="PUT", params=query)
-        if updated:
-            self.name = updated["tag"]["name"]
-
-
     def delete(self):
         return self.get_data("tags/%s" % self.name, type="DELETE")
 

--- a/digitalocean/tests/test_tag.py
+++ b/digitalocean/tests/test_tag.py
@@ -48,24 +48,6 @@ class TestTags(BaseTest):
                          self.base_url + "tags/")
         self.assertEqual(droplet_tag.name, "awesome")
 
-    @responses.activate
-    def test_update_tag(self):
-        data = self.load_from_file('tags/updatetag.json')
-
-        url = self.base_url + "tags/awesome"
-        responses.add(responses.PUT,
-                      url,
-                      body=data,
-                      status=200,
-                      content_type='application/json')
-
-        droplet_tag = digitalocean.Tag(name='awesome', token=self.token)
-        droplet_tag.update_tag(name="extra-awesome")
-
-        self.assertEqual(responses.calls[0].request.url,
-                         self.base_url + "tags/awesome")
-        self.assertEqual(droplet_tag.name, "extra-awesome")
-
 
     @responses.activate
     def test_delete(self):


### PR DESCRIPTION
Fixes: #194

https://developers.digitalocean.com/documentation/changelog/api-v2/deprecating-update-tag/