### PR TITLE
Add support for configuring domain record TTLs.

### DIFF
--- a/digitalocean/Record.py
+++ b/digitalocean/Record.py
@@ -11,6 +11,7 @@ class Record(BaseAPI):
         self.data = None
         self.priority = None
         self.port = None
+        self.ttl = None
         self.weight = None
 
         super(Record, self).__init__(*args, **kwargs)
@@ -34,6 +35,7 @@ class Record(BaseAPI):
             "name": self.name,
             "priority": self.priority,
             "port": self.port,
+            "ttl": self.ttl,
             "weight": self.weight
         }
 
@@ -65,6 +67,7 @@ class Record(BaseAPI):
             "name": self.name,
             "priority": self.priority,
             "port": self.port,
+            "ttl": self.ttl,
             "weight": self.weight,
         }
         return self.get_data(

--- a/digitalocean/tests/data/domains/create_record.json
+++ b/digitalocean/tests/data/domains/create_record.json
@@ -6,6 +6,7 @@
     "data": "@",
     "priority": null,
     "port": null,
+    "ttl": 600,
     "weight": null
   }
 }

--- a/digitalocean/tests/data/domains/records.json
+++ b/digitalocean/tests/data/domains/records.json
@@ -7,6 +7,7 @@
       "data": "8.8.8.8",
       "priority": null,
       "port": null,
+      "ttl": 1800,
       "weight": null
     },
     {
@@ -16,6 +17,7 @@
       "data": "NS1.DIGITALOCEAN.COM.",
       "priority": null,
       "port": null,
+      "ttl": 1800,
       "weight": null
     },
     {
@@ -25,6 +27,7 @@
       "data": "NS2.DIGITALOCEAN.COM.",
       "priority": null,
       "port": null,
+      "ttl": 1800,
       "weight": null
     },
     {
@@ -34,6 +37,7 @@
       "data": "NS3.DIGITALOCEAN.COM.",
       "priority": null,
       "port": null,
+      "ttl": 1800,
       "weight": null
     },
     {
@@ -43,6 +47,7 @@
       "data": "@",
       "priority": null,
       "port": null,
+      "ttl": 600,
       "weight": null
     }
   ],

--- a/digitalocean/tests/test_domain.py
+++ b/digitalocean/tests/test_domain.py
@@ -65,6 +65,7 @@ class TestDomain(BaseTest):
         self.assertEqual(response['domain_record']['type'], "CNAME")
         self.assertEqual(response['domain_record']['name'], "www")
         self.assertEqual(response['domain_record']['data'], "@")
+        self.assertEqual(response['domain_record']['ttl'], 600)
 
     @responses.activate
     def test_create(self):
@@ -107,6 +108,8 @@ class TestDomain(BaseTest):
         self.assertEqual(records[0].name, "@")
         self.assertEqual(records[4].type, "CNAME")
         self.assertEqual(records[4].name, "example")
+        self.assertEqual(records[4].ttl, 600)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
:wave:  Hi! Just a tiny update based on this a new capability:

https://developers.digitalocean.com/documentation/changelog/api-v2/configurable-ttl-for-domain-records/