### PR TITLE
Add save method for LoadBalancer

### DIFF
--- a/digitalocean/tests/data/loadbalancer/save.json
+++ b/digitalocean/tests/data/loadbalancer/save.json
@@ -1,0 +1,76 @@
+{
+  "load_balancer": {
+    "id": "4de7ac8b-495b-4884-9a69-1050c6793cd6",
+    "name": "example-lb-01",
+    "ip": "104.131.186.241",
+    "algorithm": "least_connections",
+    "status": "active",
+    "created_at": "2017-02-01T22:22:58Z",
+    "forwarding_rules": [
+      {
+        "entry_protocol": "http",
+        "entry_port": 80,
+        "target_protocol": "http",
+        "target_port": 80,
+        "certificate_id": "",
+        "tls_passthrough": false
+      },
+      {
+        "entry_protocol": "https",
+        "entry_port": 444,
+        "target_protocol": "https",
+        "target_port": 443,
+        "certificate_id": "",
+        "tls_passthrough": true
+      }
+    ],
+    "health_check": {
+      "protocol": "http",
+      "port": 80,
+      "path": "/",
+      "check_interval_seconds": 10,
+      "response_timeout_seconds": 5,
+      "healthy_threshold": 5,
+      "unhealthy_threshold": 3
+    },
+    "sticky_sessions": {
+      "type": "cookies",
+      "cookie_name": "DO_LB",
+      "cookie_ttl_seconds": 300
+    },
+    "region": {
+      "name": "New York 3",
+      "slug": "nyc3",
+      "sizes": [
+        "512mb",
+        "1gb",
+        "2gb",
+        "4gb",
+        "8gb",
+        "16gb",
+        "m-16gb",
+        "32gb",
+        "m-32gb",
+        "48gb",
+        "m-64gb",
+        "64gb",
+        "m-128gb",
+        "m-224gb"
+      ],
+      "features": [
+        "private_networking",
+        "backups",
+        "ipv6",
+        "metadata",
+        "install_agent"
+      ],
+      "available": true
+    },
+    "tag": "",
+    "droplet_ids": [
+      34153248,
+      34153250
+    ],
+    "redirect_http_to_https": false
+  }
+}


### PR DESCRIPTION
This adds a save method to the LoadBalancer class that allows us to save and update the changed attributes of the LoadBalancer.

This mirrors the [update a load balancer](https://developers.digitalocean.com/documentation/v2/#update-a-load-balancer) API.

I had to change the StickySessions class slightly because the `cookie_name` and `cookie_ttl_seconds` attribute would not be set, which would make this line `data['sticky_sessions'] = self.sticky_sessions.__dict__` fail.