### PR TITLE
Add support for CAA records.

### DIFF
--- a/digitalocean/Record.py
+++ b/digitalocean/Record.py
@@ -3,6 +3,23 @@ from .baseapi import BaseAPI, POST, DELETE, PUT
 
 
 class Record(BaseAPI):
+    """
+    An object representing an DigitalOcean Domain Record.
+
+    Args:
+        type (str): The type of the DNS record (e.g. A, CNAME, TXT).
+        name (str): The host name, alias, or service being defined by the
+            record.
+        data (int): Variable data depending on record type.
+        priority (int): The priority for SRV and MX records.
+        port (int): The port for SRV records.
+        ttl (int): The time to live for the record, in seconds.
+        weight (int): The weight for SRV records.
+        flags (int): An unsigned integer between 0-255 used for CAA records.
+        tags (string): The parameter tag for CAA records. Valid values are
+            "issue", "wildissue", or "iodef"
+    """
+
     def __init__(self, domain_name=None, *args, **kwargs):
         self.domain = domain_name if domain_name else ""
         self.id = None
@@ -13,6 +30,8 @@ class Record(BaseAPI):
         self.port = None
         self.ttl = None
         self.weight = None
+        self.flags = None
+        self.tags = None
 
         super(Record, self).__init__(*args, **kwargs)
 
@@ -27,7 +46,20 @@ class Record(BaseAPI):
 
     def create(self):
         """
-            Create a record for a domain
+        Creates a new record for a domain.
+
+        Args:
+            type (str): The type of the DNS record (e.g. A, CNAME, TXT).
+            name (str): The host name, alias, or service being defined by the
+                record.
+            data (int): Variable data depending on record type.
+            priority (int): The priority for SRV and MX records.
+            port (int): The port for SRV records.
+            ttl (int): The time to live for the record, in seconds.
+            weight (int): The weight for SRV records.
+            flags (int): An unsigned integer between 0-255 used for CAA records.
+            tags (string): The parameter tag for CAA records. Valid values are
+                "issue", "wildissue", or "iodef"
         """
         input_params = {
             "type": self.type,
@@ -36,7 +68,9 @@ class Record(BaseAPI):
             "priority": self.priority,
             "port": self.port,
             "ttl": self.ttl,
-            "weight": self.weight
+            "weight": self.weight,
+            "flags": self.flags,
+            "tags": self.tags
         }
 
         data = self.get_data(
@@ -69,6 +103,8 @@ class Record(BaseAPI):
             "port": self.port,
             "ttl": self.ttl,
             "weight": self.weight,
+            "flags": self.flags,
+            "tags": self.tags
         }
         return self.get_data(
             "domains/%s/records/%s" % (self.domain, self.id),

--- a/digitalocean/tests/data/domains/records.json
+++ b/digitalocean/tests/data/domains/records.json
@@ -8,7 +8,9 @@
       "priority": null,
       "port": null,
       "ttl": 1800,
-      "weight": null
+      "weight": null,
+      "flags": null,
+      "tag": null
     },
     {
       "id": 2,
@@ -18,7 +20,9 @@
       "priority": null,
       "port": null,
       "ttl": 1800,
-      "weight": null
+      "weight": null,
+      "flags": null,
+      "tag": null
     },
     {
       "id": 3,
@@ -28,7 +32,9 @@
       "priority": null,
       "port": null,
       "ttl": 1800,
-      "weight": null
+      "weight": null,
+      "flags": null,
+      "tag": null
     },
     {
       "id": 4,
@@ -38,7 +44,9 @@
       "priority": null,
       "port": null,
       "ttl": 1800,
-      "weight": null
+      "weight": null,
+      "flags": null,
+      "tag": null
     },
     {
       "id": 5,
@@ -48,7 +56,21 @@
       "priority": null,
       "port": null,
       "ttl": 600,
-      "weight": null
+      "weight": null,
+      "flags": null,
+      "tag": null
+    },
+    {
+      "id": 6,
+      "type": "CAA",
+      "name": "@",
+      "data": "letsencrypt.org.",
+      "priority": null,
+      "port": null,
+      "ttl": 1800,
+      "weight": null,
+      "flags": 0,
+      "tag": "issue"
     }
   ],
   "meta": {

--- a/digitalocean/tests/test_domain.py
+++ b/digitalocean/tests/test_domain.py
@@ -103,12 +103,13 @@ class TestDomain(BaseTest):
         records = self.domain.get_records()
 
         self.assert_get_url_equal(responses.calls[0].request.url, url)
-        self.assertEqual(len(records), 5)
+        self.assertEqual(len(records), 6)
         self.assertEqual(records[0].type, "A")
         self.assertEqual(records[0].name, "@")
         self.assertEqual(records[4].type, "CNAME")
         self.assertEqual(records[4].name, "example")
         self.assertEqual(records[4].ttl, 600)
+        self.assertEqual(records[5].data, "letsencrypt.org.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
:wave:  A recent update to the DO API added support for the new CAA record type:

https://developers.digitalocean.com/documentation/changelog/api-v2/caa-support-for-domain-record-resources/

This PR brings that into python-digitalocean.