### PR TITLE
Remove trailing slash from request to retrieve all tags

### DIFF
--- a/digitalocean/Manager.py
+++ b/digitalocean/Manager.py
@@ -215,7 +215,7 @@ class Manager(BaseAPI):
         """
             This method returns a list of all tags.
         """
-        data = self.get_data("tags/")
+        data = self.get_data("tags")
         return [
             Tag(token=self.token, **tag) for tag in data['tags']
         ]

--- a/digitalocean/tests/test_manager.py
+++ b/digitalocean/tests/test_manager.py
@@ -487,7 +487,7 @@ class TestManager(BaseTest):
     def test_get_all_tags(self):
         data = self.load_from_file('tags/all.json')
 
-        url = self.base_url + 'tags/'
+        url = self.base_url + 'tags'
         responses.add(responses.GET, url,
                       body=data,
                       status=200,


### PR DESCRIPTION
Calls to `Manager.get_all_tags()` started throwing a `NotFoundError` for me.

I turned on logging and confirmed that the call to `https://api.digitalocean.com/v2/tags/?per_page=200` is returning a 404. I validated this by directly submitting the request:

    $ curl "https://api.digitalocean.com/v2/tags/?per_page=200" \ 
       -H "Authorization: Bearer <token>"
    {"error":"route not found","root_causes":[]}

Removing the trailing slash from the request returned the expected response object both in curl and through the library.

This is also consistent with the [API documentation](https://developers.digitalocean.com/documentation/v2/#list-all-tags):

> To list all of your tags, you can send a GET request to `/v2/tags`.
