### PR TITLE
Added create_from_snapshot method to Volume object

### DIFF
--- a/digitalocean/Volume.py
+++ b/digitalocean/Volume.py
@@ -11,6 +11,7 @@ class Volume(BaseAPI):
         self.description = None
         self.size_gigabytes = None
         self.created_at = None
+        self.snapshot_id = None
 
         super(Volume, self).__init__(*args, **kwargs)
 
@@ -52,6 +53,34 @@ class Volume(BaseAPI):
                              type=POST,
                              params={'name': self.name,
                                      'region': self.region,
+                                     'size_gigabytes': self.size_gigabytes,
+                                     'description': self.description})
+
+        if data:
+            self.id = data['volume']['id']
+            self.created_at = data['volume']['created_at']
+
+        return self
+
+    def create_from_snapshot(self, *args, **kwargs):
+        """
+        Creates a Block Storage volume
+
+        Note: Every argument and parameter given to this method will be
+        assigned to the object.
+
+        Args:
+            name: string - a name for the volume
+            snapshot_id: string - unique identifier for the volume snapshot
+            size_gigabytes: int - size of the Block Storage volume in GiB
+
+        Optional Args:
+            description: string - text field to describe a volume
+        """
+        data = self.get_data('volumes/',
+                             type=POST,
+                             params={'name': self.name,
+                                     'snapshot_id': self.snapshot_id,
                                      'size_gigabytes': self.size_gigabytes,
                                      'description': self.description})
 

--- a/digitalocean/tests/test_volume.py
+++ b/digitalocean/tests/test_volume.py
@@ -53,6 +53,27 @@ class TestVolume(BaseTest):
         self.assertEqual(volume.size_gigabytes, 100)
 
     @responses.activate
+    def test_create_from_snapshot(self):
+        data = self.load_from_file('volumes/single.json')
+
+        url = self.base_url + "volumes/"
+        responses.add(responses.POST,
+                      url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        volume = digitalocean.Volume(droplet_id=12345,
+                                     snapshot_id='234234qwer',
+                                     size_gigabytes=100,
+                                     token=self.token).create()
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.base_url + "volumes/")
+        self.assertEqual(volume.id, "506f78a4-e098-11e5-ad9f-000f53306ae1")
+        self.assertEqual(volume.size_gigabytes, 100)
+
+    @responses.activate
     def test_destroy(self):
         volume_path = "volumes/506f78a4-e098-11e5-ad9f-000f53306ae1/"
         url = self.base_url + volume_path


### PR DESCRIPTION
- Creating a Volume from a snapshot object seems impossible, given that a region slug is required by the Python API for creation. 
- The DO API allows creation via a snapshot_id, but region cannot be specified at the same time (?? odd choice)
- Added a `create_from_snapshot` method to the Volume object to keep things separate
- Also added a `snapshot_id` attribute to the Volume object, as it seems this is necessary for the Python API to work

Thanks for the great module!