### PR TITLE
Add support for SSL certs generated by Let's Encrypt.

### DIFF
--- a/digitalocean/Certificate.py
+++ b/digitalocean/Certificate.py
@@ -10,13 +10,20 @@ class Certificate(BaseAPI):
 
     Args:
         name (str): A name for the Certificate
-        private_key (str): The contents of a PEM-formatted private-key
-            corresponding to the SSL certificate
-        leaf_certificate (str): The contents of a PEM-formatted public SSL
-            certificate
-        certificate_chain (str): The full PEM-formatted trust chain between the
-            certificate authority's certificate and your domain's SSL
-            certificate
+        private_key (str, optional): The contents of a PEM-formatted
+            private-key corresponding to the SSL certificate. Only used
+            when uploading a custom certificate.
+        leaf_certificate (str, optional): The contents of a PEM-formatted
+            public SSL certificate. Only used when uploading a custom
+            certificate.
+        certificate_chain (str, optional): The full PEM-formatted trust chain
+            between the certificate authority's certificate and your domain's
+            SSL certificate. Only used when uploading a custom certificate.
+        dns_names (:obj:`str`): A list of fully qualified domain names (FQDNs)
+            for which the certificate will be issued by Let's Encrypt
+        type (str): Specifies the type of certificate to be created. The value
+            should be "custom" for a user-uploaded certificate or
+            "lets_encrypt" for one automatically generated with Let's Encrypt.
 
     Attributes returned by API:
         name (str): The name of the Certificate
@@ -27,6 +34,13 @@ class Certificate(BaseAPI):
             generated from its SHA-1 fingerprint
         created_at (str): A string that represents when the Certificate was
             created
+        dns_names (:obj:`str`): A list of fully qualified domain names (FQDNs)
+            for which a Let's Encrypt generated certificate is issued.
+        type (str): Specifies the type of certificate. The value will be
+            "custom" for a user-uploaded certificate or "lets_encrypt" for one
+            automatically generated with Let's Encrypt.
+        state (str): Represents the current state of the certificate. It may be
+            "pending", "verified", or "errored".
     """
     def __init__(self, *args, **kwargs):
         self.id = ""
@@ -37,6 +51,9 @@ class Certificate(BaseAPI):
         self.not_after = None
         self.sha1_fingerprint = None
         self.created_at = None
+        self.dns_names = []
+        self.type = None
+        self.state = None
 
         super(Certificate, self).__init__(*args, **kwargs)
 
@@ -69,6 +86,8 @@ class Certificate(BaseAPI):
         """
         params = {
             "name": self.name,
+            "type": self.type,
+            "dns_names": self.dns_names,
             "private_key": self.private_key,
             "leaf_certificate": self.leaf_certificate,
             "certificate_chain": self.certificate_chain
@@ -81,6 +100,9 @@ class Certificate(BaseAPI):
             self.not_after = data['certificate']['not_after']
             self.sha1_fingerprint = data['certificate']['sha1_fingerprint']
             self.created_at = data['certificate']['created_at']
+            self.type = data['certificate']['type']
+            self.dns_names = data['certificate']['dns_names']
+            self.state = data['certificate']['state']
 
         return self
 

--- a/digitalocean/tests/data/certificate/custom.json
+++ b/digitalocean/tests/data/certificate/custom.json
@@ -4,6 +4,9 @@
     "name": "web-cert-01",
     "not_after": "2017-02-22T00:23:00Z",
     "sha1_fingerprint": "dfcc9f57d86bf58e321c2c6c31c7a971be244ac7",
-    "created_at": "2017-02-08T16:02:37Z"
+    "created_at": "2017-02-08T16:02:37Z",
+    "dns_names": [""],
+    "state": "verified",
+    "type": "custom"
   }
 }

--- a/digitalocean/tests/data/certificate/lets_encrpyt.json
+++ b/digitalocean/tests/data/certificate/lets_encrpyt.json
@@ -1,0 +1,12 @@
+{
+  "certificate": {
+        "id": "ba9b9c18-6c59-46c2-99df-70da170a42ba",
+        "name": "web-cert-02",
+        "not_after": "2018-06-07T17:44:12Z",
+        "sha1_fingerprint": "479c82b5c63cb6d3e6fac4624d58a33b267e166c",
+        "created_at": "2018-03-09T18:44:11Z",
+        "dns_names": ["www.example.com","example.com"],
+        "state": "pending",
+        "type": "lets_encrypt"
+    }
+}

--- a/digitalocean/tests/data/certificate/list.json
+++ b/digitalocean/tests/data/certificate/list.json
@@ -5,12 +5,25 @@
       "name": "web-cert-01",
       "not_after": "2017-02-22T00:23:00Z",
       "sha1_fingerprint": "dfcc9f57d86bf58e321c2c6c31c7a971be244ac7",
-      "created_at": "2017-02-08T16:02:37Z"
+      "created_at": "2017-02-08T16:02:37Z",
+      "dns_names": [""],
+      "state": "verified",
+      "type": "custom"
+    },
+    {
+      "id": "ba9b9c18-6c59-46c2-99df-70da170a42ba",
+      "name": "web-cert-02",
+      "not_after": "2018-06-07T17:44:12Z",
+      "sha1_fingerprint": "479c82b5c63cb6d3e6fac4624d58a33b267e166c",
+      "created_at": "2018-03-09T18:44:11Z",
+      "dns_names": ["www.example.com","example.com"],
+      "state": "pending",
+      "type": "lets_encrypt"
     }
   ],
   "links": {
   },
   "meta": {
-    "total": 1
+    "total": 2
   }
 }

--- a/digitalocean/tests/test_certificate.py
+++ b/digitalocean/tests/test_certificate.py
@@ -15,7 +15,7 @@ class TestCertificate(BaseTest):
 
     @responses.activate
     def test_load(self):
-        data = self.load_from_file('certificate/single.json')
+        data = self.load_from_file('certificate/custom.json')
         url = self.base_url + 'certificates/' + self.cert_id
 
         responses.add(responses.GET,
@@ -35,8 +35,8 @@ class TestCertificate(BaseTest):
         self.assertEqual(self.cert.created_at, '2017-02-08T16:02:37Z')
 
     @responses.activate
-    def test_create_ids(self):
-        data = self.load_from_file('certificate/single.json')
+    def test_create_custom(self):
+        data = self.load_from_file('certificate/custom.json')
         url = self.base_url + 'certificates/'
 
         responses.add(responses.POST,
@@ -46,9 +46,10 @@ class TestCertificate(BaseTest):
                       content_type='application/json')
 
         cert = digitalocean.Certificate(name='web-cert-01',
-                                        private_key = "a-b-c",
-                                        leaf_certificate = "e-f-g",
-                                        certificate_chain = "a-b-c\ne-f-g",
+                                        private_key="a-b-c",
+                                        leaf_certificate="e-f-g",
+                                        certificate_chain="a-b-c\ne-f-g",
+                                        type="custom",
                                         token=self.token).create()
 
         self.assertEqual(responses.calls[0].request.url, url)
@@ -58,6 +59,34 @@ class TestCertificate(BaseTest):
             'dfcc9f57d86bf58e321c2c6c31c7a971be244ac7')
         self.assertEqual(cert.not_after, '2017-02-22T00:23:00Z')
         self.assertEqual(cert.created_at, '2017-02-08T16:02:37Z')
+        self.assertEqual(cert.type, 'custom')
+
+    @responses.activate
+    def test_create_lets_encrypt(self):
+        data = self.load_from_file('certificate/lets_encrpyt.json')
+        url = self.base_url + 'certificates/'
+
+        responses.add(responses.POST,
+                      url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        cert = digitalocean.Certificate(name='web-cert-02',
+                                        dns_names=["www.example.com",
+                                                   "example.com"],
+                                        type="lets_encrpyt",
+                                        token=self.token).create()
+
+        self.assertEqual(responses.calls[0].request.url, url)
+        self.assertEqual(cert.id, 'ba9b9c18-6c59-46c2-99df-70da170a42ba')
+        self.assertEqual(cert.name, 'web-cert-02')
+        self.assertEqual(cert.sha1_fingerprint,
+            '479c82b5c63cb6d3e6fac4624d58a33b267e166c')
+        self.assertEqual(cert.not_after, '2018-06-07T17:44:12Z')
+        self.assertEqual(cert.created_at, '2018-03-09T18:44:11Z')
+        self.assertEqual(cert.type, 'lets_encrypt')
+        self.assertEqual(cert.state, 'pending')
 
     @responses.activate
     def test_destroy(self):

--- a/digitalocean/tests/test_manager.py
+++ b/digitalocean/tests/test_manager.py
@@ -466,6 +466,17 @@ class TestManager(BaseTest):
             'dfcc9f57d86bf58e321c2c6c31c7a971be244ac7')
         self.assertEqual(certs[0].not_after, '2017-02-22T00:23:00Z')
         self.assertEqual(certs[0].created_at, '2017-02-08T16:02:37Z')
+        self.assertEqual(certs[0].type, 'custom')
+        self.assertEqual(certs[0].state, 'verified')
+
+        self.assertEqual(certs[1].id, 'ba9b9c18-6c59-46c2-99df-70da170a42ba')
+        self.assertEqual(certs[1].name, 'web-cert-02')
+        self.assertEqual(certs[1].sha1_fingerprint,
+            '479c82b5c63cb6d3e6fac4624d58a33b267e166c')
+        self.assertEqual(certs[1].not_after, '2018-06-07T17:44:12Z')
+        self.assertEqual(certs[1].created_at, '2018-03-09T18:44:11Z')
+        self.assertEqual(certs[1].type, 'lets_encrypt')
+        self.assertEqual(certs[1].state, 'pending')
 
     @responses.activate
     def test_get_all_volumes(self):


### PR DESCRIPTION
The DO API was just extended to support generating SSL certs with Let's Encrypt. This PR adds support here.

See: https://developers.digitalocean.com/documentation/changelog/api-v2/lets-encrypt-support-for-certificate-resources/