### PR TITLE
Add support for fetching volumes per region

### DIFF
--- a/digitalocean/Manager.py
+++ b/digitalocean/Manager.py
@@ -332,11 +332,15 @@ class Manager(BaseAPI):
             for snapshot in data['snapshots']
         ]
 
-    def get_all_volumes(self):
+    def get_all_volumes(self, region=None):
         """
             This function returns a list of Volume objects.
         """
-        data = self.get_data("volumes")
+        if region:
+            url = "volumes?region={}".format(region)
+        else:
+            url = "volumes"
+        data = self.get_data(url)
         volumes = list()
         for jsoned in data['volumes']:
             volume = Volume(**jsoned)

--- a/digitalocean/tests/data/volumes/all.json
+++ b/digitalocean/tests/data/volumes/all.json
@@ -37,8 +37,8 @@
     {
       "id": "2d2967ff-491d-11e6-860c-000f53315870",
       "region": {
-        "name": "New York 1",
-        "slug": "nyc1",
+        "name": "New York 3",
+        "slug": "nyc3",
         "sizes": [
           "512mb",
           "1gb",

--- a/digitalocean/tests/test_manager.py
+++ b/digitalocean/tests/test_manager.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 import responses
 import digitalocean
@@ -494,6 +495,26 @@ class TestManager(BaseTest):
         self.assertEqual(volumes[0].id, "506f78a4-e098-11e5-ad9f-000f53306ae1")
         self.assertEqual(volumes[0].region['slug'], 'nyc1')
         self.assertEqual(volumes[0].filesystem_type, "ext4")
+        self.assertEqual(len(volumes), 2)
+
+    @responses.activate
+    def test_get_per_region_volumes(self):
+        data = json.loads(self.load_from_file('volumes/all.json'))
+        data["volumes"] = [
+            volume for volume in data["volumes"]
+            if volume["region"]["slug"] == "nyc1"]
+
+        url = self.base_url + "volumes?region=nyc1"
+        responses.add(responses.GET,
+                      url,
+                      body=json.dumps(data),
+                      status=200,
+                      content_type='application/json')
+        volumes = self.manager.get_all_volumes("nyc1")
+
+        self.assertEqual(volumes[0].id, "506f78a4-e098-11e5-ad9f-000f53306ae1")
+        self.assertEqual(volumes[0].region['slug'], 'nyc1')
+        self.assertEqual(len(volumes), 1)
 
     @responses.activate
     def test_get_all_tags(self):


### PR DESCRIPTION
Provide optional parameter to get_all_volumes to only fetch volumes on a specific region.