### PR TITLE
Add a python-digitalocean specific user agent to requests.

### DIFF
--- a/digitalocean/baseapi.py
+++ b/digitalocean/baseapi.py
@@ -3,6 +3,7 @@ import os
 import json
 import logging
 import requests
+from . import __name__, __version__
 try:
     import urlparse
 except ImportError:
@@ -51,13 +52,13 @@ class BaseAPI(object):
 
         for attr in kwargs.keys():
             setattr(self, attr, kwargs[attr])
-            
+
     def __getstate__(self):
         state = self.__dict__.copy()
         # The logger is not pickleable due to using thread.lock
         del state['_log']
         return state
-    
+
     def __setstate__(self, state):
         self.__dict__ = state
         self._log = logging.getLogger(__name__)
@@ -93,7 +94,12 @@ class BaseAPI(object):
         }
 
         requests_method, headers, payload, transform = lookup[type]
-        headers.update({'Authorization': 'Bearer ' + self.token})
+        agent = "{0}/{1} {2}/{3}".format('python-digitalocean',
+                                         __version__,
+                                         requests.__name__,
+                                         requests.__version__)
+        headers.update({'Authorization': 'Bearer ' + self.token,
+                        'User-Agent': agent})
         kwargs = {'headers': headers, payload: transform(params)}
 
         timeout = self.get_timeout()

--- a/digitalocean/tests/test_baseapi.py
+++ b/digitalocean/tests/test_baseapi.py
@@ -1,0 +1,31 @@
+import responses
+import requests
+import digitalocean
+
+from .BaseTest import BaseTest
+
+
+class TestBaseAPI(BaseTest):
+
+    def setUp(self):
+        super(TestBaseAPI, self).setUp()
+        self.manager = digitalocean.Manager(token=self.token)
+        self.user_agent = "{0}/{1} {2}/{3}".format('python-digitalocean',
+                                                   digitalocean.__version__,
+                                                   requests.__name__,
+                                                   requests.__version__)
+
+    @responses.activate
+    def test_user_agent(self):
+        data = self.load_from_file('account/account.json')
+
+        url = self.base_url + 'account/'
+        responses.add(responses.GET, url,
+                      body=data,
+                      status=200,
+                      content_type='application/json')
+
+        self.manager.get_account()
+
+        self.assertEqual(responses.calls[0].request.headers['User-Agent'],
+                         self.user_agent)


### PR DESCRIPTION
Though it might be useful for python-digitalocean to set its own user agent. Currently it defaults to `python-request/$version`