### PR TITLE
Remove trailing slash from request to retrieve tag

### DIFF
--- a/digitalocean/Tag.py
+++ b/digitalocean/Tag.py
@@ -37,7 +37,7 @@ class Tag(BaseAPI):
 
         params = {"name": self.name}
 
-        output = self.get_data("tags/", type="POST", params=params)
+        output = self.get_data("tags", type="POST", params=params)
         if output:
             self.name = output['tag']['name']
             self.resources = output['tag']['resources']

--- a/digitalocean/tests/test_tag.py
+++ b/digitalocean/tests/test_tag.py
@@ -34,7 +34,7 @@ class TestTags(BaseTest):
     def test_create(self):
         data = self.load_from_file('tags/single.json')
 
-        url = self.base_url + "tags/"
+        url = self.base_url + "tags"
         responses.add(responses.POST,
                       url,
                       body=data,

--- a/digitalocean/tests/test_tag.py
+++ b/digitalocean/tests/test_tag.py
@@ -45,7 +45,7 @@ class TestTags(BaseTest):
         droplet_tag.create()
 
         self.assertEqual(responses.calls[0].request.url,
-                         self.base_url + "tags/")
+                         self.base_url + "tags")
         self.assertEqual(droplet_tag.name, "awesome")
 
 


### PR DESCRIPTION
This was fixed for the `get_all_tags()` function in PR #230, but was not fixed for the function to create new tags.

creating new tags is resulting in a `NotFoundError` exception. This should fix it.