### PR TITLE
Changes in init to make documentation aligned with code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ MANIFEST
 .cache
 
 .venv
+docs/_build/*

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ## Table of Contents
 
 - [How to install](#how-to-install)
-- [Features](#features)  
+- [Features](#features)
 - [Examples](#examples)
    - [Listing the droplets](#listing-the-droplets)
    - [Listing the droplets by tags](#listing-the-droplets-by-tags)
@@ -55,6 +55,8 @@ python-digitalocean support all the features provided via digitalocean.com APIs,
 * Perform Snapshot
 * Enable/Disable automatic Backups
 * Restore root password of a Droplet
+* Work with Load Balancers
+* Manage your firewalls
 
 **[⬆ back to top](#table-of-contents)**
 
@@ -65,7 +67,7 @@ This example shows how to list all the active droplets:
 
 ```python
 import digitalocean
-manager = digitalocean.Manager(token="secretspecialuniquesnowflake")
+manager = digitalocean.Manager.Manager(token="secretspecialuniquesnowflake")
 my_droplets = manager.get_all_droplets()
 print(my_droplets)
 ```
@@ -78,7 +80,7 @@ This example shows how to list all the active droplets:
 
 ```python
 import digitalocean
-manager = digitalocean.Manager(token="secretspecialuniquesnowflake")
+manager = digitalocean.Manager.Manager(token="secretspecialuniquesnowflake")
 my_droplets = manager.get_all_droplets(tag_name="awesome")
 print(my_droplets)
 ```
@@ -91,7 +93,7 @@ This example shows how to add a tag to a droplet:
 
 ```python
 import digitalocean
-tag = digitalocean.Tag(token="secretspecialuniquesnowflake", name="tag_name")
+tag = digitalocean.Tag.Tag(token="secretspecialuniquesnowflake", name="tag_name")
 tag.create() # create tag if not already created
 tag.add_droplets(["DROPLET_ID"])
 ```
@@ -104,7 +106,7 @@ This example shows how to shutdown all the active droplets:
 
 ```python
 import digitalocean
-manager = digitalocean.Manager(token="secretspecialuniquesnowflake")
+manager = digitalocean.Manager.Manager(token="secretspecialuniquesnowflake")
 my_droplets = manager.get_all_droplets()
 for droplet in my_droplets:
     droplet.shutdown()
@@ -118,7 +120,7 @@ This example shows how to create a droplet and how to check its status
 
 ```python
 import digitalocean
-droplet = digitalocean.Droplet(token="secretspecialuniquesnowflake",
+droplet = digitalocean.Droplet.Droplet(token="secretspecialuniquesnowflake",
                                name='Example',
                                region='nyc2', # New York 2
                                image='ubuntu-14-04-x64', # Ubuntu 14.04 x64
@@ -145,7 +147,7 @@ for action in actions:
 from digitalocean import SSHKey
 
 user_ssh_key = open('/home/<$USER>/.ssh/id_rsa.pub').read()
-key = SSHKey(token='secretspecialuniquesnowflake',
+key = SSHKey.SSHKey(token='secretspecialuniquesnowflake',
              name='uniquehostname',
              public_key=user_ssh_key)
 key.create()
@@ -155,7 +157,7 @@ key.create()
 
 ### Creating a new droplet with all your SSH keys
 ```python
-manager = digitalocean.Manager(token="secretspecialuniquesnowflake")
+manager = digitalocean.Manager.Manager(token="secretspecialuniquesnowflake")
 keys = manager.get_all_sshkeys()
 
 droplet = digitalocean.Droplet(token="secretspecialuniquesnowflake",
@@ -175,7 +177,7 @@ droplet.create()
 This example creates a firewall that only accepts inbound tcp traffic on port 80 from a specific load balancer and allows outbout tcp traffic on all ports to all addresses.
 
 ```python
-from digitalocean import Firewall, InboundRule, OutboundRule, Destinations, Sources
+from digitalocean.LoadBalancer import Firewall, InboundRule, OutboundRule, Destinations, Sources
 
 inbound_rule = InboundRule(protocol="tcp", ports="80",
                            sources=Sources(
@@ -208,9 +210,9 @@ Each request will also include the rate limit information:
 
 ```python
 import digitalocean
-account = digitalocean.Account(token="secretspecialuniquesnowflake").load()
+account = digitalocean.Account.Account(token="secretspecialuniquesnowflake").load()
 # or
-manager = digitalocean.Manager(token="secretspecialuniquesnowflake")
+manager = digitalocean.Manager.Manager(token="secretspecialuniquesnowflake")
 account = manager.get_account()
 ```
 Output:
@@ -232,7 +234,7 @@ uuid: 'my_id'
 When using the Manager().get_all.. functions, the rate limit will be stored on the manager object:
  ```python
 import digitalocean
-manager = digitalocean.Manager(token="secretspecialuniquesnowflake")
+manager = digitalocean.Manager.Manager(token="secretspecialuniquesnowflake")
 domains = manager.get_all_domains()
 
 print(manager.ratelimit_limit)

--- a/digitalocean/__init__.py
+++ b/digitalocean/__init__.py
@@ -7,23 +7,22 @@ __author_email__ = "lorenzo@setale.me"
 __license__ = "LGPL v3"
 __copyright__ = "Copyright (c) 2012, 2013, 2014, 2015, 2016, 2017, 2018 Lorenzo Setale"
 
-from .Manager import Manager
-from .Droplet import Droplet, DropletError, BadKernelObject, BadSSHKeyFormat
-from .Region import Region
-from .Size import Size
-from .Image import Image
-from .Action import Action
-from .Account import Account
-from .Domain import Domain
-from .Record import Record
-from .SSHKey import SSHKey
-from .Kernel import Kernel
-from .FloatingIP import FloatingIP
-from .Volume import Volume
-from .baseapi import Error, TokenError, DataReadError
-from .Tag import Tag
-from .LoadBalancer import LoadBalancer
-from .LoadBalancer import StickySesions, ForwardingRule, HealthCheck
-from .Certificate import Certificate
-from .Snapshot import Snapshot
-from .Firewall import Firewall, InboundRule, OutboundRule, Destinations, Sources
+import Manager
+import Droplet
+import Region
+import Size
+import Image
+import Action
+import Account
+import Domain
+import Record
+import SSHKey
+import Kernel
+import FloatingIP
+import Volume
+import baseapi
+import Tag
+import LoadBalancer
+import Certificate
+import Snapshot
+import Firewall

--- a/digitalocean/__init__.py
+++ b/digitalocean/__init__.py
@@ -7,22 +7,22 @@ __author_email__ = "lorenzo@setale.me"
 __license__ = "LGPL v3"
 __copyright__ = "Copyright (c) 2012, 2013, 2014, 2015, 2016, 2017, 2018 Lorenzo Setale"
 
-import Manager
-import Droplet
-import Region
-import Size
-import Image
-import Action
-import Account
-import Domain
-import Record
-import SSHKey
-import Kernel
-import FloatingIP
-import Volume
-import baseapi
-import Tag
-import LoadBalancer
-import Certificate
-import Snapshot
-import Firewall
+import digitalocean.Manager
+import digitalocean.Droplet
+import digitalocean.Region
+import digitalocean.Size
+import digitalocean.Image
+import digitalocean.Action
+import digitalocean.Account
+import digitalocean.Domain
+import digitalocean.Record
+import digitalocean.SSHKey
+import digitalocean.Kernel
+import digitalocean.FloatingIP
+import digitalocean.Volume
+import digitalocean.baseapi
+import digitalocean.Tag
+import digitalocean.LoadBalancer
+import digitalocean.Certificate
+import digitalocean.Snapshot
+import digitalocean.Firewall

--- a/digitalocean/tests/test_action.py
+++ b/digitalocean/tests/test_action.py
@@ -10,7 +10,7 @@ class TestAction(BaseTest):
 
     def setUp(self):
         super(TestAction, self).setUp()
-        self.action = digitalocean.Action(id=39388122, token=self.token)
+        self.action = digitalocean.Action.Action(id=39388122, token=self.token)
 
     @responses.activate
     def test_load_directly(self):

--- a/digitalocean/tests/test_baseapi.py
+++ b/digitalocean/tests/test_baseapi.py
@@ -9,7 +9,7 @@ class TestBaseAPI(BaseTest):
 
     def setUp(self):
         super(TestBaseAPI, self).setUp()
-        self.manager = digitalocean.Manager(token=self.token)
+        self.manager = digitalocean.Manager.Manager(token=self.token)
         self.user_agent = "{0}/{1} {2}/{3}".format('python-digitalocean',
                                                    digitalocean.__version__,
                                                    requests.__name__,

--- a/digitalocean/tests/test_certificate.py
+++ b/digitalocean/tests/test_certificate.py
@@ -11,7 +11,7 @@ class TestCertificate(BaseTest):
     def setUp(self):
         super(TestCertificate, self).setUp()
         self.cert_id = '892071a0-bb95-49bc-8021-3afd67a210bf'
-        self.cert = digitalocean.Certificate(id=self.cert_id, token=self.token)
+        self.cert = digitalocean.Certificate.Certificate(id=self.cert_id, token=self.token)
 
     @responses.activate
     def test_load(self):
@@ -45,7 +45,7 @@ class TestCertificate(BaseTest):
                       status=201,
                       content_type='application/json')
 
-        cert = digitalocean.Certificate(name='web-cert-01',
+        cert = digitalocean.Certificate.Certificate(name='web-cert-01',
                                         private_key="a-b-c",
                                         leaf_certificate="e-f-g",
                                         certificate_chain="a-b-c\ne-f-g",
@@ -72,7 +72,7 @@ class TestCertificate(BaseTest):
                       status=201,
                       content_type='application/json')
 
-        cert = digitalocean.Certificate(name='web-cert-02',
+        cert = digitalocean.Certificate.Certificate(name='web-cert-02',
                                         dns_names=["www.example.com",
                                                    "example.com"],
                                         type="lets_encrpyt",

--- a/digitalocean/tests/test_domain.py
+++ b/digitalocean/tests/test_domain.py
@@ -11,7 +11,7 @@ class TestDomain(BaseTest):
 
     def setUp(self):
         super(TestDomain, self).setUp()
-        self.domain = digitalocean.Domain(name='example.com', token=self.token)
+        self.domain = digitalocean.Domain.Domain(name='example.com', token=self.token)
 
     @responses.activate
     def test_load(self):
@@ -24,7 +24,7 @@ class TestDomain(BaseTest):
                       status=200,
                       content_type='application/json')
 
-        domain = digitalocean.Domain(name='example.com', token=self.token)
+        domain = digitalocean.Domain.Domain(name='example.com', token=self.token)
         domain.load()
 
         self.assert_get_url_equal(responses.calls[0].request.url, url)
@@ -78,7 +78,7 @@ class TestDomain(BaseTest):
                       status=201,
                       content_type='application/json')
 
-        domain = digitalocean.Domain(name="example.com",
+        domain = digitalocean.Domain.Domain(name="example.com",
                                      ip_address="1.1.1.1",
                                      token=self.token).create()
 

--- a/digitalocean/tests/test_droplet.py
+++ b/digitalocean/tests/test_droplet.py
@@ -21,7 +21,7 @@ class TestDroplet(BaseTest):
                       body=data,
                       status=200,
                       content_type='application/json')
-        self.droplet = digitalocean.Droplet(id='12345', token=self.token).load()
+        self.droplet = digitalocean.Droplet.Droplet(id='12345', token=self.token).load()
 
     @responses.activate
     def test_load(self):
@@ -34,7 +34,7 @@ class TestDroplet(BaseTest):
                       status=200,
                       content_type='application/json')
 
-        droplet = digitalocean.Droplet(id='12345', token=self.token)
+        droplet = digitalocean.Droplet.Droplet(id='12345', token=self.token)
         d = droplet.load()
 
         self.assert_get_url_equal(responses.calls[0].request.url, url)
@@ -752,7 +752,7 @@ class TestDroplet(BaseTest):
                       status=201,
                       content_type='application/json')
 
-        response = self.droplet.change_kernel(digitalocean.Kernel(id=123))
+        response = self.droplet.change_kernel(digitalocean.Droplet.Kernel(id=123))
 
         self.assert_url_query_equal(responses.calls[0].request.url,
                                     self.actions_url)
@@ -773,7 +773,7 @@ class TestDroplet(BaseTest):
                       status=201,
                       content_type='application/json')
 
-        response = self.droplet.change_kernel(digitalocean.Kernel(id=123),
+        response = self.droplet.change_kernel(digitalocean.Droplet.Kernel(id=123),
                                               return_dict=False)
 
         self.assert_url_query_equal(responses.calls[0].request.url,
@@ -797,7 +797,7 @@ class TestDroplet(BaseTest):
                       status=202,
                       content_type='application/json')
 
-        droplet = digitalocean.Droplet(name="example.com",
+        droplet = digitalocean.Droplet.Droplet(name="example.com",
                                        size_slug="512mb",
                                        image="ubuntu-14-04-x64",
                                        region="nyc3",
@@ -835,7 +835,7 @@ class TestDroplet(BaseTest):
                       content_type='application/json')
 
 
-        droplets = digitalocean.Droplet.create_multiple(names=["example.com",
+        droplets = digitalocean.Droplet.Droplet.create_multiple(names=["example.com",
                                                                "example2.com"],
                                                         size_slug="512mb",
                                                         image="ubuntu-14-04-x64",

--- a/digitalocean/tests/test_firewall.py
+++ b/digitalocean/tests/test_firewall.py
@@ -21,7 +21,7 @@ class TestFirewall(BaseTest):
                       status=200,
                       content_type='application/json')
 
-        self.firewall = digitalocean.Firewall(id=12345, token=self.token).load()
+        self.firewall = digitalocean.Firewall.Firewall(id=12345, token=self.token).load()
 
     @responses.activate
     def test_load(self):
@@ -34,7 +34,7 @@ class TestFirewall(BaseTest):
                       status=200,
                       content_type='application/json')
 
-        firewall = digitalocean.Firewall(id=12345, token=self.token)
+        firewall = digitalocean.Firewall.Firewall(id=12345, token=self.token)
         f = firewall.load()
 
         self.assert_get_url_equal(responses.calls[0].request.url, url)
@@ -88,7 +88,7 @@ class TestFirewall(BaseTest):
         droplet_id = json.loads(data)["droplet_ids"][0]
         self.firewall.remove_droplets([droplet_id])
 
-        self.assertEqual(responses.calls[0].request.url, url)    
+        self.assertEqual(responses.calls[0].request.url, url)
 
     @responses.activate
     def test_add_tags(self):

--- a/digitalocean/tests/test_floatingip.py
+++ b/digitalocean/tests/test_floatingip.py
@@ -9,7 +9,7 @@ class TestFloatingIP(BaseTest):
 
     def setUp(self):
         super(TestFloatingIP, self).setUp()
-        self.fip = digitalocean.FloatingIP(ip='45.55.96.47', token=self.token)
+        self.fip = digitalocean.FloatingIP.FloatingIP(ip='45.55.96.47', token=self.token)
 
     @responses.activate
     def test_load(self):
@@ -39,7 +39,7 @@ class TestFloatingIP(BaseTest):
                       status=201,
                       content_type='application/json')
 
-        fip = digitalocean.FloatingIP(droplet_id=12345,
+        fip = digitalocean.FloatingIP.FloatingIP(droplet_id=12345,
                                       token=self.token).create()
 
         self.assertEqual(responses.calls[0].request.url,
@@ -58,7 +58,7 @@ class TestFloatingIP(BaseTest):
                       status=201,
                       content_type='application/json')
 
-        fip = digitalocean.FloatingIP(region_slug='nyc3',
+        fip = digitalocean.FloatingIP.FloatingIP(region_slug='nyc3',
                                       token=self.token).reserve()
 
         self.assertEqual(responses.calls[0].request.url,

--- a/digitalocean/tests/test_image.py
+++ b/digitalocean/tests/test_image.py
@@ -9,10 +9,10 @@ class TestImage(BaseTest):
 
     def setUp(self):
         super(TestImage, self).setUp()
-        self.image = digitalocean.Image(
+        self.image = digitalocean.Image.Image(
             id=449676856,  token=self.token
         )
-        self.image_with_slug = digitalocean.Image(
+        self.image_with_slug = digitalocean.Image.Image(
             slug='testslug', token=self.token
         )
 
@@ -75,7 +75,7 @@ class TestImage(BaseTest):
                       status=202,
                       content_type='application/json')
 
-        image = digitalocean.Image(name='ubuntu-18.04-minimal',
+        image = digitalocean.Image.Image(name='ubuntu-18.04-minimal',
                                    url='https://www.example.com/cloud.img',
                                    distribution='Ubuntu',
                                    region='nyc3',

--- a/digitalocean/tests/test_load_balancer.py
+++ b/digitalocean/tests/test_load_balancer.py
@@ -11,7 +11,7 @@ class TestLoadBalancer(BaseTest):
     def setUp(self):
         super(TestLoadBalancer, self).setUp()
         self.lb_id = '4de7ac8b-495b-4884-9a69-1050c6793cd6'
-        self.lb = digitalocean.LoadBalancer(id=self.lb_id, token=self.token)
+        self.lb = digitalocean.LoadBalancer.LoadBalancer(id=self.lb_id, token=self.token)
 
     @responses.activate
     def test_load(self):
@@ -55,18 +55,18 @@ class TestLoadBalancer(BaseTest):
                       status=201,
                       content_type='application/json')
 
-        rule1 = digitalocean.ForwardingRule(entry_port=80,
+        rule1 = digitalocean.LoadBalancer.ForwardingRule(entry_port=80,
                                             entry_protocol='http',
                                             target_port=80,
                                             target_protocol='http')
-        rule2 = digitalocean.ForwardingRule(entry_port=443,
+        rule2 = digitalocean.LoadBalancer.ForwardingRule(entry_port=443,
                                             entry_protocol='https',
                                             target_port=443,
                                             target_protocol='https',
                                             tls_passthrough=True)
-        check = digitalocean.HealthCheck()
-        sticky = digitalocean.StickySesions(type='none')
-        lb = digitalocean.LoadBalancer(name='example-lb-01', region='nyc3',
+        check = digitalocean.LoadBalancer.HealthCheck()
+        sticky = digitalocean.LoadBalancer.StickySesions(type='none')
+        lb = digitalocean.LoadBalancer.LoadBalancer(name='example-lb-01', region='nyc3',
                                        algorithm='round_robin',
                                        forwarding_rules=[rule1, rule2],
                                        health_check=check,
@@ -103,18 +103,18 @@ class TestLoadBalancer(BaseTest):
                       status=201,
                       content_type='application/json')
 
-        rule1 = digitalocean.ForwardingRule(entry_port=80,
+        rule1 = digitalocean.LoadBalancer.ForwardingRule(entry_port=80,
                                             entry_protocol='http',
                                             target_port=80,
                                             target_protocol='http')
-        rule2 = digitalocean.ForwardingRule(entry_port=443,
+        rule2 = digitalocean.LoadBalancer.ForwardingRule(entry_port=443,
                                             entry_protocol='https',
                                             target_port=443,
                                             target_protocol='https',
                                             tls_passthrough=True)
-        check = digitalocean.HealthCheck()
-        sticky = digitalocean.StickySesions(type='none')
-        lb = digitalocean.LoadBalancer(name='example-lb-01', region='nyc3',
+        check = digitalocean.LoadBalancer.HealthCheck()
+        sticky = digitalocean.LoadBalancer.StickySesions(type='none')
+        lb = digitalocean.LoadBalancer.LoadBalancer(name='example-lb-01', region='nyc3',
                                        algorithm='round_robin',
                                        forwarding_rules=[rule1, rule2],
                                        health_check=check,
@@ -153,13 +153,13 @@ class TestLoadBalancer(BaseTest):
                       status=201,
                       content_type='application/json')
 
-        rule = digitalocean.ForwardingRule(entry_port=80,
+        rule = digitalocean.LoadBalancer.ForwardingRule(entry_port=80,
                                            entry_protocol='http',
                                            target_port=80,
                                            target_protocol='http')
-        check = digitalocean.HealthCheck()
-        sticky = digitalocean.StickySesions(type='none')
-        lb = digitalocean.LoadBalancer(name='example-lb-01', region='nyc3',
+        check = digitalocean.LoadBalancer.HealthCheck()
+        sticky = digitalocean.LoadBalancer.StickySesions(type='none')
+        lb = digitalocean.LoadBalancer.LoadBalancer(name='example-lb-01', region='nyc3',
                                        algorithm='round_robin',
                                        forwarding_rules=[rule],
                                        health_check=check,
@@ -233,12 +233,12 @@ class TestLoadBalancer(BaseTest):
         self.lb.droplet_ids = [34153248, 34153250]
         res = self.lb.save()
 
-        lb = digitalocean.LoadBalancer(**res['load_balancer'])
-        lb.health_check = digitalocean.HealthCheck(**res['load_balancer']['health_check'])
-        lb.sticky_sessions = digitalocean.StickySesions(**res['load_balancer']['sticky_sessions'])
+        lb = digitalocean.LoadBalancer.LoadBalancer(**res['load_balancer'])
+        lb.health_check = digitalocean.LoadBalancer.HealthCheck(**res['load_balancer']['health_check'])
+        lb.sticky_sessions = digitalocean.LoadBalancer.StickySesions(**res['load_balancer']['sticky_sessions'])
         rules = list()
         for rule in lb.forwarding_rules:
-            rules.append(digitalocean.ForwardingRule(**rule))
+            rules.append(digitalocean.LoadBalancer.ForwardingRule(**rule))
         self.assertEqual(lb.id, self.lb_id)
         self.assertEqual(lb.region['slug'], 'nyc3')
         self.assertEqual(lb.algorithm, 'least_connections')
@@ -322,7 +322,7 @@ class TestLoadBalancer(BaseTest):
                       status=204,
                       content_type='application/json')
 
-        rule = digitalocean.ForwardingRule(entry_port=3306,
+        rule = digitalocean.LoadBalancer.ForwardingRule(entry_port=3306,
                                            entry_protocol='tcp',
                                            target_port=3306,
                                            target_protocol='tcp')
@@ -355,7 +355,7 @@ class TestLoadBalancer(BaseTest):
                       status=204,
                       content_type='application/json')
 
-        rule = digitalocean.ForwardingRule(entry_port=3306,
+        rule = digitalocean.LoadBalancer.ForwardingRule(entry_port=3306,
                                            entry_protocol='tcp',
                                            target_port=3306,
                                            target_protocol='tcp')

--- a/digitalocean/tests/test_manager.py
+++ b/digitalocean/tests/test_manager.py
@@ -10,8 +10,8 @@ class TestManager(BaseTest):
 
     def setUp(self):
         super(TestManager, self).setUp()
-        self.manager = digitalocean.Manager(token=self.token)
-        self.image = digitalocean.Image(
+        self.manager = digitalocean.Manager.Manager(token=self.token)
+        self.image = digitalocean.Image.Image(
             id=449676856, slug='testslug', token=self.token
         )
 
@@ -44,7 +44,7 @@ class TestManager(BaseTest):
                       status=401,
                       content_type='application/json')
 
-        bad_token = digitalocean.Manager(token='thisisnotagoodtoken')
+        bad_token = digitalocean.Manager.Manager(token='thisisnotagoodtoken')
         with self.assertRaises(Exception) as error:
             bad_token.get_all_regions()
 
@@ -106,7 +106,7 @@ class TestManager(BaseTest):
                       status=200,
                       content_type="application/json")
 
-        manager = digitalocean.Manager(token=self.token)
+        manager = digitalocean.Manager.Manager(token=self.token)
         droplets = manager.get_all_droplets(tag_name="awesome")
 
         droplet = droplets[0]

--- a/digitalocean/tests/test_snapshot.py
+++ b/digitalocean/tests/test_snapshot.py
@@ -9,7 +9,7 @@ class TestSnapshot(BaseTest):
 
     def setUp(self):
         super(TestSnapshot, self).setUp()
-        self.snapshot = digitalocean.Snapshot(id="fbe805e8-866b-11e6-96bf-000f53315a41", token=self.token)
+        self.snapshot = digitalocean.Snapshot.Snapshot(id="fbe805e8-866b-11e6-96bf-000f53315a41", token=self.token)
 
     @responses.activate
     def test_load(self):

--- a/digitalocean/tests/test_tag.py
+++ b/digitalocean/tests/test_tag.py
@@ -22,7 +22,7 @@ class TestTags(BaseTest):
                       status=200,
                       content_type='application/json')
 
-        droplet_tag = digitalocean.Tag(name='awesome', token=self.token)
+        droplet_tag = digitalocean.Tag.Tag(name='awesome', token=self.token)
         droplet_tag.load()
 
         self.assert_get_url_equal(responses.calls[0].request.url, url)
@@ -41,7 +41,7 @@ class TestTags(BaseTest):
                       status=201,
                       content_type='application/json')
 
-        droplet_tag = digitalocean.Tag(name='awesome', token=self.token)
+        droplet_tag = digitalocean.Tag.Tag(name='awesome', token=self.token)
         droplet_tag.create()
 
         self.assertEqual(responses.calls[0].request.url,
@@ -57,7 +57,7 @@ class TestTags(BaseTest):
                       status=204,
                       content_type='application/json')
 
-        droplet_tag = digitalocean.Tag(name='awesome', token=self.token)
+        droplet_tag = digitalocean.Tag.Tag(name='awesome', token=self.token)
         droplet_tag.delete()
 
         self.assertEqual(responses.calls[0].request.url,
@@ -78,7 +78,7 @@ class TestTags(BaseTest):
 
         resource_id = json.loads(data)["resources"][0]["resource_id"]
 
-        droplet_tag = digitalocean.Tag(name='awesome', token=self.token)
+        droplet_tag = digitalocean.Tag.Tag(name='awesome', token=self.token)
         droplet_tag.add_droplets([resource_id])
 
         self.assertEqual(responses.calls[0].request.url,
@@ -98,7 +98,7 @@ class TestTags(BaseTest):
 
         resource_id = json.loads(data)["resources"][0]["resource_id"]
 
-        droplet_tag = digitalocean.Tag(name='awesome', token=self.token)
+        droplet_tag = digitalocean.Tag.Tag(name='awesome', token=self.token)
         droplet_tag.remove_droplets([resource_id])
 
         self.assertEqual(responses.calls[0].request.url,

--- a/digitalocean/tests/test_volume.py
+++ b/digitalocean/tests/test_volume.py
@@ -9,7 +9,7 @@ class TestVolume(BaseTest):
 
     def setUp(self):
         super(TestVolume, self).setUp()
-        self.volume = digitalocean.Volume(
+        self.volume = digitalocean.Volume.Volume(
             id='506f78a4-e098-11e5-ad9f-000f53306ae1', token=self.token)
 
     @responses.activate
@@ -42,7 +42,7 @@ class TestVolume(BaseTest):
                       status=201,
                       content_type='application/json')
 
-        volume = digitalocean.Volume(droplet_id=12345,
+        volume = digitalocean.Volume.Volume(droplet_id=12345,
                                      region='nyc1',
                                      size_gigabytes=100,
                                      filesystem_type='ext4',
@@ -66,7 +66,7 @@ class TestVolume(BaseTest):
                       status=201,
                       content_type='application/json')
 
-        volume = digitalocean.Volume(droplet_id=12345,
+        volume = digitalocean.Volume.Volume(droplet_id=12345,
                                      snapshot_id='234234qwer',
                                      region='nyc1',
                                      size_gigabytes=100,

--- a/docs/digitalocean.rst
+++ b/docs/digitalocean.rst
@@ -61,7 +61,7 @@ digitalocean.Kernel module
     :show-inheritance:
 
 digitalocean.LoadBalancer module
---------------------------
+--------------------------------
 
 .. automodule:: digitalocean.LoadBalancer
     :members:


### PR DESCRIPTION
Changing __init__.py so that imports and docs have the same path.
For example:
old way:
import digitalocean
digitalocean.ForwardingRule()
new way:
import digitalocean
digitalocean.LoadBalancer.ForwardingRule()