### PR TITLE
Added request.Session usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ MANIFEST
 .venv
 
 *.sw[pon]
+.eggs

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ MANIFEST
 .cache
 
 .venv
+
+*.sw[pon]

--- a/digitalocean/baseapi.py
+++ b/digitalocean/baseapi.py
@@ -50,6 +50,8 @@ class BaseAPI(object):
         self.end_point = "https://api.digitalocean.com/v2/"
         self._log = logging.getLogger(__name__)
 
+        self._session = requests.Session()
+
         for attr in kwargs.keys():
             setattr(self, attr, kwargs[attr])
 
@@ -83,12 +85,12 @@ class BaseAPI(object):
         identity = lambda x: x
         json_dumps = lambda x: json.dumps(x)
         lookup = {
-            GET: (requests.get, {}, 'params', identity),
-            POST: (requests.post, {'Content-type': 'application/json'}, 'data',
+            GET: (self._session.get, {}, 'params', identity),
+            POST: (self._session.post, {'Content-type': 'application/json'}, 'data',
                    json_dumps),
-            PUT: (requests.put, {'Content-type': 'application/json'}, 'data',
+            PUT: (self._session.put, {'Content-type': 'application/json'}, 'data',
                   json_dumps),
-            DELETE: (requests.delete,
+            DELETE: (self._session.delete,
                      {'content-type': 'application/json'},
                      'data', json_dumps),
         }

--- a/digitalocean/tests/test_baseapi.py
+++ b/digitalocean/tests/test_baseapi.py
@@ -29,3 +29,15 @@ class TestBaseAPI(BaseTest):
 
         self.assertEqual(responses.calls[0].request.headers['User-Agent'],
                          self.user_agent)
+
+    @responses.activate
+    def test_customize_session(self):
+        data = self.load_from_file('account/account.json')
+        url = self.base_url + 'account/'
+        responses.add(responses.GET, url,
+                      body=data,
+                      status=200,
+                      content_type='application/json')
+
+        self.manager._session.proxies['https'] = 'https://127.0.0.1:3128'
+        self.manager.get_account()


### PR DESCRIPTION
This was using the high-level method available in requests.

Instead of that, here we use a Session object with exactly the same methods.
The difference is that I'm storing this object as class attribute of BaseAPI and users could:
- Set retry, timeout, etc
- Set handlers
- Reuse their own client