### PR TITLE
Call load_directly() for Actions without a droplet.id

### DIFF
--- a/digitalocean/Action.py
+++ b/digitalocean/Action.py
@@ -39,12 +39,15 @@ class Action(BaseAPI):
                 setattr(self, attr, action[attr])
 
     def load(self):
-        action = self.get_data(
-            "droplets/%s/actions/%s" % (
-                self.droplet_id,
-                self.id
+        if not self.droplet_id:
+            action = self.load_directly()
+        else:
+            action = self.get_data(
+                "droplets/%s/actions/%s" % (
+                    self.droplet_id,
+                    self.id
+                )
             )
-        )
         if action:
             action = action[u'action']
             # Loading attributes

--- a/digitalocean/tests/test_action.py
+++ b/digitalocean/tests/test_action.py
@@ -30,5 +30,24 @@ class TestAction(BaseTest):
         self.assertEqual(self.action.id, 39388122)
         self.assertEqual(self.action.region_slug, 'nyc3')
 
+    @responses.activate
+    def test_load_without_droplet_id(self):
+        data = self.load_from_file('actions/ipv6_completed.json')
+
+        url = self.base_url + "actions/39388122"
+        responses.add(responses.GET,
+                      url,
+                      body=data,
+                      status=200,
+                      content_type='application/json')
+
+        self.action.load()
+
+        self.assert_get_url_equal(responses.calls[0].request.url, url)
+        self.assertEqual(self.action.status, "completed")
+        self.assertEqual(self.action.id, 39388122)
+        self.assertEqual(self.action.region_slug, 'nyc3')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I've noticed requests being made to URLs with `None` in the path like: `https://api.digitalocean.com/v2/droplets/None/actions/39388122` While they actually do succed for Droplet-related Actions, there is no real guarantee that they will continue to in the future.

The `Action.load()` method assumes that a Droplet ID has been set, but not all Actions are Droplet-related. There is a `load_directly()` method that calls `https://api.digitalocean.com/v2/actions/39388122`. This PR makes it so `load()` falls back to `load_directly()` if there is no Droplet ID.

Example of the new test failing without the fix:

```
=================================== FAILURES ===================================
___________________ TestAction.test_load_without_droplet_id ____________________

self = <digitalocean.tests.test_action.TestAction testMethod=test_load_without_droplet_id>

    @responses.activate
    def test_load_without_droplet_id(self):
        data = self.load_from_file('actions/ipv6_completed.json')
    
        url = self.base_url + "actions/39388122"
        responses.add(responses.GET,
                      url,
                      body=data,
                      status=200,
                      content_type='application/json')
    
>       self.action.load()

digitalocean/tests/test_action.py:44: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
digitalocean/Action.py:45: in load
    self.id
digitalocean/baseapi.py:182: in get_data
    req = self.__perform_request(url, type, params)
digitalocean/baseapi.py:116: in __perform_request
    return requests_method(url, **kwargs)
/usr/local/lib/python3.6/site-packages/requests/sessions.py:546: in get
    return self.request('GET', url, **kwargs)
/usr/local/lib/python3.6/site-packages/requests/sessions.py:533: in request
    resp = self.send(prep, **send_kwargs)
/usr/local/lib/python3.6/site-packages/requests/sessions.py:646: in send
    r = adapter.send(request, **kwargs)
/usr/local/lib/python3.6/site-packages/responses.py:626: in unbound_on_send
    return self._on_request(adapter, request, *a, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <responses.RequestsMock object at 0x7f4d44067208>
adapter = <requests.adapters.HTTPAdapter object at 0x7f4d49c777f0>
request = <PreparedRequest [GET]>
kwargs = {'cert': None, 'proxies': OrderedDict(), 'stream': False, 'timeout': None, ...}
match = None, resp_callback = None
error_msg = "Connection refused by Responses: GET https://api.digitalocean.com/v2/droplets/None/actions/39388122?per_page=200 doesn't match Responses Mock"
response = ConnectionError("Connection refused by Responses: GET https://api.digitalocean.com/v2/droplets/None/actions/39388122?per_page=200 doesn't match Responses Mock",)

    def _on_request(self, adapter, request, **kwargs):
        match = self._find_match(request)
        resp_callback = self.response_callback
    
        if match is None:
            if request.url.startswith(self.passthru_prefixes):
                logger.info("request.allowed-passthru", extra={"url": request.url})
                return _real_send(adapter, request, **kwargs)
    
            error_msg = (
                "Connection refused by Responses: {0} {1} doesn't "
                "match Responses Mock".format(request.method, request.url)
            )
            response = ConnectionError(error_msg)
            response.request = request
    
            self._calls.add(request, response)
            response = resp_callback(response) if resp_callback else response
>           raise response
E           requests.exceptions.ConnectionError: Connection refused by Responses: GET https://api.digitalocean.com/v2/droplets/None/actions/39388122?per_page=200 doesn't match Responses Mock

/usr/local/lib/python3.6/site-packages/responses.py:601: ConnectionError
===================== 1 failed, 125 passed in 1.06 seconds =====================
```