### PR TITLE
Default to DIGITALOCEAN_ACCESS_TOKEN env var

### DIFF
--- a/digitalocean/baseapi.py
+++ b/digitalocean/baseapi.py
@@ -46,7 +46,7 @@ class BaseAPI(object):
     end_point = "https://api.digitalocean.com/v2/"
 
     def __init__(self, *args, **kwargs):
-        self.token = ""
+        self.token = os.getenv("DIGITALOCEAN_ACCESS_TOKEN", "")
         self.end_point = "https://api.digitalocean.com/v2/"
         self._log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Instead of defaulting to an empty token, it would be really helpful to default to `DIGITALOCEAN_ACCESS_TOKEN`, like `doctl` do.