### PR TITLE
Fix errors for zero priority and weight SRV records

### DIFF
--- a/digitalocean/Domain.py
+++ b/digitalocean/Domain.py
@@ -58,13 +58,13 @@ class Domain(BaseAPI):
         }
 
         #  Optional Args
-        if kwargs.get("priority", None):
+        if kwargs.get("priority", None) == None:
             data['priority'] = kwargs.get("priority", None)
 
         if kwargs.get("port", None):
             data['port'] = kwargs.get("port", None)
 
-        if kwargs.get("weight", None):
+        if kwargs.get("weight", None) == None:
             data['weight'] = kwargs.get("weight", None)
 
         return self.get_data(

--- a/digitalocean/Domain.py
+++ b/digitalocean/Domain.py
@@ -58,13 +58,13 @@ class Domain(BaseAPI):
         }
 
         #  Optional Args
-        if kwargs.get("priority", None) == None:
+        if kwargs.get("priority", None) != None:
             data['priority'] = kwargs.get("priority", None)
 
         if kwargs.get("port", None):
             data['port'] = kwargs.get("port", None)
 
-        if kwargs.get("weight", None) == None:
+        if kwargs.get("weight", None) != None:
             data['weight'] = kwargs.get("weight", None)
 
         return self.get_data(

--- a/digitalocean/tests/data/domains/create_srv_record.json
+++ b/digitalocean/tests/data/domains/create_srv_record.json
@@ -1,0 +1,12 @@
+{
+  "domain_record": {
+    "id": 17,
+    "type": "SRV",
+    "name": "service",
+    "data": "service",
+    "priority": 0,
+    "port": 53,
+    "ttl": 600,
+    "weight": 0
+  }
+}

--- a/digitalocean/tests/test_domain.py
+++ b/digitalocean/tests/test_domain.py
@@ -68,6 +68,29 @@ class TestDomain(BaseTest):
         self.assertEqual(response['domain_record']['ttl'], 600)
 
     @responses.activate
+    def test_create_new_srv_record_zero_priority(self):
+        data = self.load_from_file('domains/create_srv_record.json')
+
+        url = self.base_url + "domains/example.com/records"
+        responses.add(responses.POST,
+                      url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        response = self.domain.create_new_domain_record(
+            type="SRV", name="service", data="service", priority=0, weight=0)
+
+        self.assert_url_query_equal(
+            responses.calls[0].request.url,
+            self.base_url + "domains/example.com/records")
+        self.assertEqual(response['domain_record']['type'], "SRV")
+        self.assertEqual(response['domain_record']['name'], "service")
+        self.assertEqual(response['domain_record']['data'], "service")
+        self.assertEqual(response['domain_record']['priority'], 0)
+        self.assertEqual(response['domain_record']['weight'], 0)
+
+    @responses.activate
     def test_create(self):
         data = self.load_from_file('domains/create.json')
 


### PR DESCRIPTION
This addresses the error which occurs when an SRV record is created with weight and/or priority of zero. Currently, the default value of `None` in the calls to `kwargs.get` results in a `None` since `if 0` is falsey.

Please let me know if you'd like any adjustments to this patch.