### PR TITLE
Volume: permit tags

### DIFF
--- a/digitalocean/Volume.py
+++ b/digitalocean/Volume.py
@@ -14,6 +14,7 @@ class Volume(BaseAPI):
         self.snapshot_id = None
         self.filesystem_type = None
         self.filesystem_label = None
+        self.tags = None
 
         super(Volume, self).__init__(*args, **kwargs)
 
@@ -54,6 +55,7 @@ class Volume(BaseAPI):
 
         Optional Args:
             description: string - text field to describe a volume
+            tags: List[string], optional - the tags to be applied to the volume
         """
         data = self.get_data('volumes/',
                              type=POST,
@@ -62,7 +64,8 @@ class Volume(BaseAPI):
                                      'size_gigabytes': self.size_gigabytes,
                                      'description': self.description,
                                      'filesystem_type': self.filesystem_type,
-                                     'filesystem_label': self.filesystem_label
+                                     'filesystem_label': self.filesystem_label,
+                                     'tags': self.tags,
                                      })
 
         if data:
@@ -89,6 +92,7 @@ class Volume(BaseAPI):
 
         Optional Args:
             description: string - text field to describe a volume
+            tags: List[string], optional - the tags to be applied to the volume
         """
         data = self.get_data('volumes/',
                              type=POST,
@@ -98,7 +102,8 @@ class Volume(BaseAPI):
                                      'size_gigabytes': self.size_gigabytes,
                                      'description': self.description,
                                      'filesystem_type': self.filesystem_type,
-                                     'filesystem_label': self.filesystem_label
+                                     'filesystem_label': self.filesystem_label,
+                                     'tags': self.tags,
                                      })
 
         if data:

--- a/digitalocean/tests/data/volumes/single_with_tags.json
+++ b/digitalocean/tests/data/volumes/single_with_tags.json
@@ -1,0 +1,40 @@
+{
+  "volume": {
+    "id": "506f78a4-e098-11e5-ad9f-000f53306ae1",
+    "region": {
+      "name": "New York 1",
+      "slug": "nyc1",
+      "sizes": [
+        "512mb",
+        "1gb",
+        "2gb",
+        "4gb",
+        "8gb",
+        "16gb",
+        "32gb",
+        "48gb",
+        "64gb"
+      ],
+      "features": [
+        "private_networking",
+        "backups",
+        "ipv6",
+        "metadata"
+      ],
+      "available": true
+    },
+    "droplet_ids": [
+
+    ],
+    "name": "example",
+    "description": "Block store for examples",
+    "size_gigabytes": 100,
+    "filesystem_label": "ext4",
+    "filesystem_label": "label",
+    "tags": [
+      "tag1",
+      "tag2"
+    ],
+    "created_at": "2016-03-02T17:00:49Z"
+  }
+}

--- a/digitalocean/tests/test_volume.py
+++ b/digitalocean/tests/test_volume.py
@@ -56,6 +56,33 @@ class TestVolume(BaseTest):
         self.assertEqual(volume.filesystem_type, "ext4")
 
     @responses.activate
+    def test_create_with_tags(self):
+        data = self.load_from_file('volumes/single_with_tags.json')
+
+        url = self.base_url + "volumes/"
+        responses.add(responses.POST,
+                      url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        volume = digitalocean.Volume(droplet_id=12345,
+                                     region='nyc1',
+                                     size_gigabytes=100,
+                                     filesystem_type='ext4',
+                                     filesystem_label='label',
+                                     tags=['tag1', 'tag2'],
+                                     token=self.token).create()
+
+        self.assertEqual(volume.tags, ['tag1', 'tag2'])
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.base_url + "volumes/")
+        self.assertEqual(volume.id, "506f78a4-e098-11e5-ad9f-000f53306ae1")
+        self.assertEqual(volume.size_gigabytes, 100)
+        self.assertEqual(volume.filesystem_type, "ext4")
+
+    @responses.activate
     def test_create_from_snapshot(self):
         data = self.load_from_file('volumes/single.json')
 


### PR DESCRIPTION
Not sure when the DO API started to permit it, but POST on `/volumes` can specify a tags attribute, which is not possible through python-digitalocean as-is, so I've added the possibility. I tested it on the live API, managed to create a tagged volume. The tags are not visible on the Volumes dashboard, but are GET-able through the API.
I've added a unit test for it, I think :-) 