### PR TITLE
Fixing documentation to allow sphinx to run without warnings

### DIFF
--- a/digitalocean/Droplet.py
+++ b/digitalocean/Droplet.py
@@ -22,7 +22,7 @@ class BadSSHKeyFormat(DropletError):
 
 
 class Droplet(BaseAPI):
-    """"Droplet management
+    """Droplet management
 
     Attributes accepted at creation time:
 
@@ -31,36 +31,37 @@ class Droplet(BaseAPI):
         size_slug (str): droplet size
         image (str): image name to use to create droplet
         region (str): region
-        ssh_keys: (:obj:`str`, optional): list of ssh keys
+        ssh_keys (:obj:`str`, optional): list of ssh keys
         backups (bool): True if backups enabled
         ipv6 (bool): True if ipv6 enabled
         private_networking (bool): True if private networking enabled
         user_data (str): arbitrary data to pass to droplet
         volumes (:obj:`str`, optional): list of blockstorage volumes
-        monitoring: (bool) - True if installing the DigitalOcean monitoring agent
+        monitoring (bool): True if installing the DigitalOcean monitoring agent
 
     Attributes returned by API:
-        id (int): droplet id
-        memory (str): memory size
-        vcpus (int): number of vcpus
-        disk (int): disk size in GB
-        status (str): status
-        locked (bool): True if locked
-        created_at (str): creation date in format u'2014-11-06T10:42:09Z'
-        status (str): status, e.g. 'new', 'active', etc
-        networks (dict): details of connected networks
-        kernel (dict): details of kernel
-        backup_ids (:obj:`int`, optional): list of ids of backups of this droplet
-        snapshot_ids (:obj:`int`, optional): list of ids of snapshots of this droplet
-        action_ids (:obj:`int`, optional): list of ids of actions
-        features (:obj:`str`, optional): list of enabled features. e.g.
-                  [u'private_networking', u'virtio']
-        image (dict): details of image used to create this droplet
-        ip_address (str): public ip addresses
-        private_ip_address (str): private ip address
-        ip_v6_address (:obj:`str`, optional): list of ipv6 addresses assigned
-        end_point (str): url of api endpoint used
-        volume_ids (:obj:`str`, optional): list of blockstorage volumes
+        * id (int): droplet id
+        * memory (str): memory size
+        * vcpus (int): number of vcpus
+        * disk (int): disk size in GB
+        * status (str): status
+        * locked (bool): True if locked
+        * created_at (str): creation date in format u'2014-11-06T10:42:09Z'
+        * status (str): status, e.g. 'new', 'active', etc
+        * networks (dict): details of connected networks
+        * kernel (dict): details of kernel
+        * backup_ids (:obj:`int`, optional): list of ids of backups of this droplet
+        * snapshot_ids (:obj:`int`, optional): list of ids of snapshots of this droplet
+        * action_ids (:obj:`int`, optional): list of ids of actions
+        * features (:obj:`str`, optional): list of enabled features. e.g.
+              [u'private_networking', u'virtio']
+        * image (dict): details of image used to create this droplet
+        * ip_address (str): public ip addresses
+        * private_ip_address (str): private ip address
+        * ip_v6_address (:obj:`str`, optional): list of ipv6 addresses assigned
+        * end_point (str): url of api endpoint used
+        * volume_ids (:obj:`str`, optional): list of blockstorage volumes
+
     """
 
     def __init__(self, *args, **kwargs):
@@ -309,8 +310,8 @@ class Droplet(BaseAPI):
             new_size_slug (str): name of new size
 
         Optional Args:
-            return_dict (bool): Return a dict when True (default),
-                                otherwise return an Action.
+            return_dict (bool): Return a dict when True (default), \
+                otherwise return an Action.
             disk (bool): If a permanent resize, with disk changes included.
 
         Returns dict or Action

--- a/digitalocean/Image.py
+++ b/digitalocean/Image.py
@@ -14,33 +14,33 @@ class Image(BaseAPI):
         region (str): The slug of the region where the image will be available.
         distribution (str, optional): The name of the image's distribution.
         description (str, optional): Free-form text field to describe an image.
-        tags (obj:`list` of `str`, optional): List of tag names to apply to
+        tags (obj:`list` of `str`, optional): List of tag names to apply to \
             the image.
 
     Attributes returned by API:
-
-        id (int): A unique number to identify and reference a image.
-        name (str): The display name given to an image.
-        type (str): The kind of image. This will be either "snapshot",
-            "backup", or "custom".
-        distribution (str): The name of the image's distribution.
-        slug (str): A uniquely identifying string that is associated with each
-            of the DigitalOcean-provided public images.
-        public (bool): Indicates whether the image is public or not.
-        regions (obj:`list` of `str`): A list of the slugs of the regions where
-            the image is available for use.
-        created_at (str): A time value given in ISO8601 combined date and time
-            format that represents when the image was created.
-        min_disk_size (int): The minimum disk size in GB required for a Droplet
-            to use this image.
-        size_gigabytes (int): The size of the image in gigabytes.
-        description (str): Free-form text field to describing an image.
-        tags (obj:`list` of `str`): List of tag names to applied to the image.
-        status (str): Indicates the state of a custom image. This may be "NEW",
-            "available", "pending", or "deleted".
-        error_message (str): Information about errors that may occur when
-            importing a custom image.
+        * id (int): A unique number to identify and reference a image.
+        * name (str): The display name given to an image.
+        * type (str): The kind of image. This will be either "snapshot",
+              "backup", or "custom".
+        * distribution (str): The name of the image's distribution.
+        * slug (str): A uniquely identifying string that is associated with each \
+              of the DigitalOcean-provided public images.
+        * public (bool): Indicates whether the image is public or not.
+        * regions (obj:`list` of `str`): A list of the slugs of the regions where \
+              the image is available for use.
+        * created_at (str): A time value given in ISO8601 combined date and time \
+              format that represents when the image was created.
+        * min_disk_size (int): The minimum disk size in GB required for a Droplet \
+              to use this image.
+        * size_gigabytes (int): The size of the image in gigabytes.
+        * description (str): Free-form text field to describing an image.
+        * tags (obj:`list` of `str`): List of tag names to applied to the image.
+        * status (str): Indicates the state of a custom image. This may be "NEW", \
+              "available", "pending", or "deleted".
+        * error_message (str): Information about errors that may occur when \
+              importing a custom image.
     """
+
     def __init__(self, *args, **kwargs):
         self.id = None
         self.name = None

--- a/digitalocean/LoadBalancer.py
+++ b/digitalocean/LoadBalancer.py
@@ -91,40 +91,40 @@ class LoadBalancer(BaseAPI):
     Args:
         name (str): The Load Balancer's name
         region (str): The slug identifier for a DigitalOcean region
-        algorithm (str, optional): The load balancing algorithm to be
-            used. Currently, it must be either "round_robin" or
+        algorithm (str, optional): The load balancing algorithm to be \
+            used. Currently, it must be either "round_robin" or \
             "least_connections"
         forwarding_rules (obj:`list`): A list of `ForwrdingRules` objects
         health_check (obj, optional): A `HealthCheck` object
         sticky_sessions (obj, optional): A `StickySessions` object
-        redirect_http_to_https (bool, optional): A boolean indicating
-            whether HTTP requests to the Load Balancer should be
+        redirect_http_to_https (bool, optional): A boolean indicating \
+            whether HTTP requests to the Load Balancer should be \
             redirected to HTTPS
-        droplet_ids (obj:`list` of `int`): A list of IDs representing
-            Droplets to be added to the Load Balancer (mutually
+        droplet_ids (obj:`list` of `int`): A list of IDs representing \
+            Droplets to be added to the Load Balancer (mutually \
             exclusive with 'tag')
-        tag (str): A string representing a DigitalOcean Droplet tag
+        tag (str): A string representing a DigitalOcean Droplet tag \
             (mutually exclusive with 'droplet_ids')
 
-   Attributes returned by API:
-        name (str): The Load Balancer's name
-        id (str): An unique identifier for a LoadBalancer
-        ip (str): Public IP address for a LoadBalancer
-        region (str): The slug identifier for a DigitalOcean region
-        algorithm (str, optional): The load balancing algorithm to be
-            used. Currently, it must be either "round_robin" or
-            "least_connections"
-        forwarding_rules (obj:`list`): A list of `ForwrdingRules` objects
-        health_check (obj, optional): A `HealthCheck` object
-        sticky_sessions (obj, optional): A `StickySessions` object
-        redirect_http_to_https (bool, optional): A boolean indicating
-            whether HTTP requests to the Load Balancer should be
-            redirected to HTTPS
-        droplet_ids (obj:`list` of `int`): A list of IDs representing
-            Droplets to be added to the Load Balancer
-        tag (str): A string representing a DigitalOcean Droplet tag
-        status (string): An indication the current state of the LoadBalancer
-        created_at (str): The date and time when the LoadBalancer was created
+    Attributes returned by API:
+        * name (str): The Load Balancer's name
+        * id (str): An unique identifier for a LoadBalancer
+        * ip (str): Public IP address for a LoadBalancer
+        * region (str): The slug identifier for a DigitalOcean region
+        * algorithm (str, optional): The load balancing algorithm to be \
+              used. Currently, it must be either "round_robin" or \
+              "least_connections"
+        * forwarding_rules (obj:`list`): A list of `ForwrdingRules` objects
+        * health_check (obj, optional): A `HealthCheck` object
+        * sticky_sessions (obj, optional): A `StickySessions` object
+        * redirect_http_to_https (bool, optional): A boolean indicating \
+              whether HTTP requests to the Load Balancer should be \
+              redirected to HTTPS
+        * droplet_ids (obj:`list` of `int`): A list of IDs representing \
+              Droplets to be added to the Load Balancer
+        * tag (str): A string representing a DigitalOcean Droplet tag
+        * status (string): An indication the current state of the LoadBalancer
+        * created_at (str): The date and time when the LoadBalancer was created
     """
     def __init__(self, *args, **kwargs):
         self.id = None

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,7 +99,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#  html_static_path = ['_static']
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/docs/digitalocean.rst
+++ b/docs/digitalocean.rst
@@ -61,7 +61,7 @@ digitalocean.Kernel module
     :show-inheritance:
 
 digitalocean.LoadBalancer module
---------------------------
+--------------------------------
 
 .. automodule:: digitalocean.LoadBalancer
     :members:


### PR DESCRIPTION
I propose this set of small fixes in documentation. If you fire up make html in docs dir, you get a lot of warnings. This change should fix the issue.

This doesn't necessarily add a lot of new stuff, but treat it as a warm up from my side :)