### PR TITLE
StickySessions typo fix + StickySessions.__init__ kwargs

### DIFF
--- a/digitalocean/LoadBalancer.py
+++ b/digitalocean/LoadBalancer.py
@@ -2,7 +2,7 @@
 from .baseapi import BaseAPI, GET, POST, PUT, DELETE
 
 
-class StickySesions(object):
+class StickySessions(object):
     """
     An object holding information on a LoadBalancer's sticky sessions settings.
 
@@ -14,7 +14,7 @@ class StickySesions(object):
         cookie_ttl_seconds (int, optional): The number of seconds until the
             cookie expires
     """
-    def __init__(self, type='none', cookie_name='', cookie_ttl_seconds=None):
+    def __init__(self, type='none', cookie_name='', cookie_ttl_seconds=None, cookie_ttl=None):
         self.type = type
         if type is 'cookies':
             self.cookie_name = 'DO-LB'
@@ -170,7 +170,7 @@ class LoadBalancer(BaseAPI):
                 health_check = HealthCheck(**load_balancer['health_check'])
                 setattr(self, attr, health_check)
             elif attr == 'sticky_sessions':
-                sticky_ses = StickySesions(**load_balancer['sticky_sessions'])
+                sticky_ses = StickySessions(**load_balancer['sticky_sessions'])
                 setattr(self, attr, sticky_ses)
             elif attr == 'forwarding_rules':
                 rules = list()
@@ -235,7 +235,7 @@ class LoadBalancer(BaseAPI):
             self.algorithm = data['load_balancer']['algorithm']
             self.health_check = HealthCheck(
                 **data['load_balancer']['health_check'])
-            self.sticky_sessions = StickySesions(
+            self.sticky_sessions = StickySessions(
                 **data['load_balancer']['sticky_sessions'])
             self.droplet_ids = data['load_balancer']['droplet_ids']
             self.status = data['load_balancer']['status']

--- a/digitalocean/LoadBalancer.py
+++ b/digitalocean/LoadBalancer.py
@@ -14,7 +14,7 @@ class StickySessions(object):
         cookie_ttl_seconds (int, optional): The number of seconds until the
             cookie expires
     """
-    def __init__(self, type='none', cookie_name='', cookie_ttl_seconds=None, cookie_ttl=None):
+    def __init__(self, type='none', cookie_name='', cookie_ttl_seconds=None, **kwargs):
         self.type = type
         if type is 'cookies':
             self.cookie_name = 'DO-LB'

--- a/digitalocean/Manager.py
+++ b/digitalocean/Manager.py
@@ -14,7 +14,7 @@ from .FloatingIP import FloatingIP
 from .Firewall import Firewall, InboundRule, OutboundRule
 from .Image import Image
 from .LoadBalancer import LoadBalancer
-from .LoadBalancer import StickySesions, HealthCheck, ForwardingRule
+from .LoadBalancer import StickySessions, HealthCheck, ForwardingRule
 from .Region import Region
 from .SSHKey import SSHKey
 from .Size import Size
@@ -255,7 +255,7 @@ class Manager(BaseAPI):
             load_balancer = LoadBalancer(**jsoned)
             load_balancer.token = self.token
             load_balancer.health_check = HealthCheck(**jsoned['health_check'])
-            load_balancer.sticky_sessions = StickySesions(**jsoned['sticky_sessions'])
+            load_balancer.sticky_sessions = StickySessions(**jsoned['sticky_sessions'])
             forwarding_rules = list()
             for rule in jsoned['forwarding_rules']:
                 forwarding_rules.append(ForwardingRule(**rule))

--- a/digitalocean/__init__.py
+++ b/digitalocean/__init__.py
@@ -23,7 +23,7 @@ from .Volume import Volume
 from .baseapi import Error, TokenError, DataReadError
 from .Tag import Tag
 from .LoadBalancer import LoadBalancer
-from .LoadBalancer import StickySesions, ForwardingRule, HealthCheck
+from .LoadBalancer import StickySessions, ForwardingRule, HealthCheck
 from .Certificate import Certificate
 from .Snapshot import Snapshot
 from .Firewall import Firewall, InboundRule, OutboundRule, Destinations, Sources

--- a/digitalocean/tests/test_load_balancer.py
+++ b/digitalocean/tests/test_load_balancer.py
@@ -65,7 +65,7 @@ class TestLoadBalancer(BaseTest):
                                             target_protocol='https',
                                             tls_passthrough=True)
         check = digitalocean.HealthCheck()
-        sticky = digitalocean.StickySesions(type='none')
+        sticky = digitalocean.StickySessions(type='none')
         lb = digitalocean.LoadBalancer(name='example-lb-01', region='nyc3',
                                        algorithm='round_robin',
                                        forwarding_rules=[rule1, rule2],
@@ -113,7 +113,7 @@ class TestLoadBalancer(BaseTest):
                                             target_protocol='https',
                                             tls_passthrough=True)
         check = digitalocean.HealthCheck()
-        sticky = digitalocean.StickySesions(type='none')
+        sticky = digitalocean.StickySessions(type='none')
         lb = digitalocean.LoadBalancer(name='example-lb-01', region='nyc3',
                                        algorithm='round_robin',
                                        forwarding_rules=[rule1, rule2],
@@ -158,7 +158,7 @@ class TestLoadBalancer(BaseTest):
                                            target_port=80,
                                            target_protocol='http')
         check = digitalocean.HealthCheck()
-        sticky = digitalocean.StickySesions(type='none')
+        sticky = digitalocean.StickySessions(type='none')
         lb = digitalocean.LoadBalancer(name='example-lb-01', region='nyc3',
                                        algorithm='round_robin',
                                        forwarding_rules=[rule],
@@ -235,7 +235,7 @@ class TestLoadBalancer(BaseTest):
 
         lb = digitalocean.LoadBalancer(**res['load_balancer'])
         lb.health_check = digitalocean.HealthCheck(**res['load_balancer']['health_check'])
-        lb.sticky_sessions = digitalocean.StickySesions(**res['load_balancer']['sticky_sessions'])
+        lb.sticky_sessions = digitalocean.StickySessions(**res['load_balancer']['sticky_sessions'])
         rules = list()
         for rule in lb.forwarding_rules:
             rules.append(digitalocean.ForwardingRule(**rule))


### PR DESCRIPTION
I suddenly started getting `TypeError: __init__() got an unexpected keyword argument 'cookie_ttl'` when trying to fetch all load balancers.  Turns out DO API is returning `cookie_ttl` instead of `cookie_ttl_seconds` in BaseAPI.get_data()

The official DO api docs describe cookie_ttl_seconds so I'm not sure why it's returning cookie_ttl.  Adding **kwargs to the init prevents the error.

Also fixed typo, StickySesions=>StickySessions

