### PR TITLE
make get_all_droplets' params configurable

### DIFF
--- a/digitalocean/Manager.py
+++ b/digitalocean/Manager.py
@@ -45,11 +45,13 @@ class Manager(BaseAPI):
             regions.append(region)
         return regions
 
-    def get_all_droplets(self, tag_name=None):
+    def get_all_droplets(self, params=None, tag_name=None):
         """
             This function returns a list of Droplet object.
         """
-        params = dict()
+        if params is None:
+            params = dict()
+
         if tag_name:
             params["tag_name"] = tag_name
 


### PR DESCRIPTION
get_all_droplets() doesn't allow to pass params like `per_page`. This tiny change makes it possible.