### PR TITLE
Fix invalid byte 0xc2

### DIFF
--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -43,7 +43,7 @@ digitalocean.com APIs, such as:
 -  Enable/Disable automatic Backups
 -  Restore root password of a Droplet
 
- Examples
+Examples
 ---------
 
 Listing the droplets


### PR DESCRIPTION
The following error occurs with Python 3.6:
Traceback (most recent call last):
  File "setup.py", line 14, in <module>
    long_description = file.read()
  File "/usr/pkg/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 820: ordinal not in range(128)