### PR TITLE
Fix python syntax to suppress 3.8 warnings about "is with a literal"

### DIFF
--- a/digitalocean/LoadBalancer.py
+++ b/digitalocean/LoadBalancer.py
@@ -16,7 +16,7 @@ class StickySesions(object):
     """
     def __init__(self, type='none', cookie_name='', cookie_ttl_seconds=None):
         self.type = type
-        if type is 'cookies':
+        if type == 'cookies':
             self.cookie_name = 'DO-LB'
             self.cookie_ttl_seconds = 300
         self.cookie_name = cookie_name


### PR DESCRIPTION
Python 3.8 is now displaying a warning when is is used with a literal.

Here are the relevant errors with 2.4.0:
```
/usr/lib/python3.8/site-packages/digitalocean/LoadBalancer.py:19: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if type is 'cookies':
```

See python/cpython#9642 for more info