### PR TITLE
Various README updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ actions = droplet.get_actions()
 for action in actions:
     action.load()
     # Once it shows complete, droplet is up and running
-    print action.status
+    print(action.status)
 ```
 
 **[⬆ back to top](#table-of-contents)**

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ droplet = digitalocean.Droplet(token="secretspecialuniquesnowflake",
                                name='Example',
                                region='nyc2', # New York 2
                                image='ubuntu-20-04-x64', # Ubuntu 20.04 x64
-                               size_slug='512mb',  # 512MB
+                               size_slug='s-1vcpu-1gb',  # 1GB RAM, 1 vCPU
                                backups=True)
 droplet.create()
 ```
@@ -189,7 +189,7 @@ droplet = digitalocean.Droplet(token="secretspecialuniquesnowflake",
                                name='DropletWithSSHKeys',
                                region='ams3', # Amster
                                image='ubuntu-20-04-x64', # Ubuntu 20.04 x64
-                               size_slug='512mb',  # 512MB
+                               size_slug='s-1vcpu-1gb',  # 1GB RAM, 1 vCPU
                                ssh_keys=keys, #Automatic conversion
                                backups=False)
 droplet.create()

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ import digitalocean
 droplet = digitalocean.Droplet(token="secretspecialuniquesnowflake",
                                name='Example',
                                region='nyc2', # New York 2
-                               image='ubuntu-14-04-x64', # Ubuntu 14.04 x64
+                               image='ubuntu-20-04-x64', # Ubuntu 20.04 x64
                                size_slug='512mb',  # 512MB
                                backups=True)
 droplet.create()
@@ -188,7 +188,7 @@ keys = manager.get_all_sshkeys()
 droplet = digitalocean.Droplet(token="secretspecialuniquesnowflake",
                                name='DropletWithSSHKeys',
                                region='ams3', # Amster
-                               image='ubuntu-14-04-x64', # Ubuntu 14.04 x64
+                               image='ubuntu-20-04-x64', # Ubuntu 20.04 x64
                                size_slug='512mb',  # 512MB
                                ssh_keys=keys, #Automatic conversion
                                backups=False)

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ droplet.create()
 actions = droplet.get_actions()
 for action in actions:
     action.load()
-    # Once it shows complete, droplet is up and running
+    # Once it shows "completed", droplet is up and running
     print(action.status)
 ```
 


### PR DESCRIPTION
I happened to be on the README, and noticed that the examples still use one of the legacy Droplet sizes that only exist for backwards compatibility and an older Ubuntu release.  This updates it to use `s-1vcpu-1gb` (the new $5 plan) and the latest Ubuntu LTS.

I fixed https://github.com/koalalorenzo/python-digitalocean/issues/303 and https://github.com/koalalorenzo/python-digitalocean/issues/304 while I was at it.