### PR TITLE
Don't include trailing slash when adding or removing Droplets. 

### DIFF
--- a/digitalocean/LoadBalancer.py
+++ b/digitalocean/LoadBalancer.py
@@ -286,7 +286,7 @@ class LoadBalancer(BaseAPI):
             droplet_ids (obj:`list` of `int`): A list of Droplet IDs
         """
         return self.get_data(
-            "load_balancers/%s/droplets/" % self.id,
+            "load_balancers/%s/droplets" % self.id,
             type=POST,
             params={"droplet_ids": droplet_ids}
         )
@@ -299,7 +299,7 @@ class LoadBalancer(BaseAPI):
             droplet_ids (obj:`list` of `int`): A list of Droplet IDs
         """
         return self.get_data(
-            "load_balancers/%s/droplets/" % self.id,
+            "load_balancers/%s/droplets" % self.id,
             type=DELETE,
             params={"droplet_ids": droplet_ids}
         )

--- a/digitalocean/tests/test_load_balancer.py
+++ b/digitalocean/tests/test_load_balancer.py
@@ -283,7 +283,7 @@ class TestLoadBalancer(BaseTest):
 
     @responses.activate
     def test_add_droplets(self):
-        url = '{0}load_balancers/{1}/droplets/'.format(self.base_url,
+        url = '{0}load_balancers/{1}/droplets'.format(self.base_url,
                                                        self.lb_id)
         responses.add(responses.POST,
                       url,
@@ -299,7 +299,7 @@ class TestLoadBalancer(BaseTest):
 
     @responses.activate
     def test_remove_droplets(self):
-        url = '{0}load_balancers/{1}/droplets/'.format(self.base_url,
+        url = '{0}load_balancers/{1}/droplets'.format(self.base_url,
                                                        self.lb_id)
         responses.add(responses.DELETE,
                       url,


### PR DESCRIPTION
The trailing slash in the URL for requests adding and removing Droplets from a load balancer is causing 404 errors.

Fixes: #314