### PR TITLE
Fix trailing slashes for LoadBalancer and Certificate APIs

### DIFF
--- a/digitalocean/Certificate.py
+++ b/digitalocean/Certificate.py
@@ -93,7 +93,7 @@ class Certificate(BaseAPI):
             "certificate_chain": self.certificate_chain
         }
 
-        data = self.get_data("certificates/", type=POST, params=params)
+        data = self.get_data("certificates", type=POST, params=params)
 
         if data:
             self.id = data['certificate']['id']

--- a/digitalocean/LoadBalancer.py
+++ b/digitalocean/LoadBalancer.py
@@ -227,7 +227,7 @@ class LoadBalancer(BaseAPI):
         if self.sticky_sessions:
             params['sticky_sessions'] = self.sticky_sessions.__dict__
 
-        data = self.get_data('load_balancers/', type=POST, params=params)
+        data = self.get_data('load_balancers', type=POST, params=params)
 
         if data:
             self.id = data['load_balancer']['id']
@@ -268,7 +268,7 @@ class LoadBalancer(BaseAPI):
         if self.sticky_sessions:
             data['sticky_sessions'] = self.sticky_sessions.__dict__
 
-        return self.get_data("load_balancers/%s/" % self.id,
+        return self.get_data("load_balancers/%s" % self.id,
                              type=PUT,
                              params=data)
 
@@ -276,7 +276,7 @@ class LoadBalancer(BaseAPI):
         """
         Destroy the LoadBalancer
         """
-        return self.get_data('load_balancers/%s/' % self.id, type=DELETE)
+        return self.get_data('load_balancers/%s' % self.id, type=DELETE)
 
     def add_droplets(self, droplet_ids):
         """
@@ -314,7 +314,7 @@ class LoadBalancer(BaseAPI):
         rules_dict = [rule.__dict__ for rule in forwarding_rules]
 
         return self.get_data(
-            "load_balancers/%s/forwarding_rules/" % self.id,
+            "load_balancers/%s/forwarding_rules" % self.id,
             type=POST,
             params={"forwarding_rules": rules_dict}
         )
@@ -329,7 +329,7 @@ class LoadBalancer(BaseAPI):
         rules_dict = [rule.__dict__ for rule in forwarding_rules]
 
         return self.get_data(
-            "load_balancers/%s/forwarding_rules/" % self.id,
+            "load_balancers/%s/forwarding_rules" % self.id,
             type=DELETE,
             params={"forwarding_rules": rules_dict}
         )

--- a/digitalocean/tests/test_certificate.py
+++ b/digitalocean/tests/test_certificate.py
@@ -37,7 +37,7 @@ class TestCertificate(BaseTest):
     @responses.activate
     def test_create_custom(self):
         data = self.load_from_file('certificate/custom.json')
-        url = self.base_url + 'certificates/'
+        url = self.base_url + 'certificates'
 
         responses.add(responses.POST,
                       url,
@@ -64,7 +64,7 @@ class TestCertificate(BaseTest):
     @responses.activate
     def test_create_lets_encrypt(self):
         data = self.load_from_file('certificate/lets_encrpyt.json')
-        url = self.base_url + 'certificates/'
+        url = self.base_url + 'certificates'
 
         responses.add(responses.POST,
                       url,

--- a/digitalocean/tests/test_load_balancer.py
+++ b/digitalocean/tests/test_load_balancer.py
@@ -48,7 +48,7 @@ class TestLoadBalancer(BaseTest):
     def test_create_ids(self):
         data = self.load_from_file('loadbalancer/single.json')
 
-        url = self.base_url + "load_balancers/"
+        url = self.base_url + "load_balancers"
         responses.add(responses.POST,
                       url,
                       body=data,
@@ -96,7 +96,7 @@ class TestLoadBalancer(BaseTest):
     def test_create_tag(self):
         data = self.load_from_file('loadbalancer/single_tag.json')
 
-        url = self.base_url + "load_balancers/"
+        url = self.base_url + "load_balancers"
         responses.add(responses.POST,
                       url,
                       body=data,
@@ -125,7 +125,7 @@ class TestLoadBalancer(BaseTest):
         resp_rules = lb.forwarding_rules
 
         self.assertEqual(responses.calls[0].request.url,
-                         self.base_url + 'load_balancers/')
+                         self.base_url + 'load_balancers')
         self.assertEqual(lb.id, '4de2ac7b-495b-4884-9e69-1050d6793cd4')
         self.assertEqual(lb.algorithm, 'round_robin')
         self.assertEqual(lb.ip, '104.131.186.248')
@@ -218,8 +218,7 @@ class TestLoadBalancer(BaseTest):
         self.assertEqual(self.lb.redirect_http_to_https, False)
 
         data2 = self.load_from_file('loadbalancer/save.json')
-        # PUT requires slash at the end of url
-        url = '{0}load_balancers/{1}/'.format(self.base_url, self.lb_id)
+        url = '{0}load_balancers/{1}'.format(self.base_url, self.lb_id)
         responses.add(responses.PUT,
                       url,
                       body=data2,
@@ -271,7 +270,7 @@ class TestLoadBalancer(BaseTest):
 
     @responses.activate
     def test_destroy(self):
-        url = '{0}load_balancers/{1}/'.format(self.base_url, self.lb_id)
+        url = '{0}load_balancers/{1}'.format(self.base_url, self.lb_id)
         responses.add(responses.DELETE,
                       url,
                       status=204,
@@ -315,7 +314,7 @@ class TestLoadBalancer(BaseTest):
 
     @responses.activate
     def test_add_forwarding_rules(self):
-        url = '{0}load_balancers/{1}/forwarding_rules/'.format(self.base_url,
+        url = '{0}load_balancers/{1}/forwarding_rules'.format(self.base_url,
                                                                self.lb_id)
         responses.add(responses.POST,
                       url,
@@ -348,7 +347,7 @@ class TestLoadBalancer(BaseTest):
 
     @responses.activate
     def test_remove_forwarding_rules(self):
-        url = '{0}load_balancers/{1}/forwarding_rules/'.format(self.base_url,
+        url = '{0}load_balancers/{1}/forwarding_rules'.format(self.base_url,
                                                                self.lb_id)
         responses.add(responses.DELETE,
                       url,


### PR DESCRIPTION
## Context

- Closes #323 - More details on the issue description

## Proposed solution

I updated the API paths according to the official digital ocean docs:

https://developers.digitalocean.com/documentation/v2/#load-balancers
https://developers.digitalocean.com/documentation/v2/#certificates

## Integration tests

I suggest using this simple script to perform requests on the API. you can also run the script on this branch and also on master to assure the behavior is fixed.

```python
import os
import digitalocean
DIGITALOCEAN_API_TOKEN = os.environ.get("DIGITALOCEAN_API_TOKEN")
LOAD_BALANCER_NAME = "lb-api-sandbox" # Change this to a load balancer in your account
do = digitalocean.Manager(token=DIGITALOCEAN_API_TOKEN)
lbs = do.get_all_load_balancers()
lb = list(filter(lambda x: x.name == LOAD_BALANCER_NAME, lbs))[0]
lb.save()
```
