### PR TITLE
Add new loadbalancer options to the loadbalancer object

### DIFF
--- a/digitalocean/LoadBalancer.py
+++ b/digitalocean/LoadBalancer.py
@@ -91,6 +91,9 @@ class LoadBalancer(BaseAPI):
     Args:
         name (str): The Load Balancer's name
         region (str): The slug identifier for a DigitalOcean region
+        size (str): The size of the load balancer. The available sizes \
+            are "lb-small", "lb-medium", or "lb-large". Once you have \
+            created a load balancer, you can't change its size
         algorithm (str, optional): The load balancing algorithm to be \
             used. Currently, it must be either "round_robin" or \
             "least_connections"
@@ -100,6 +103,11 @@ class LoadBalancer(BaseAPI):
         redirect_http_to_https (bool, optional): A boolean indicating \
             whether HTTP requests to the Load Balancer should be \
             redirected to HTTPS
+        enable_proxy_protocol (bool, optional): A boolean value indicating \
+            whether PROXY Protocol is in use
+        enable_backend_keepalive (bool, optional): A boolean value \
+            indicating whether HTTP keepalive connections are maintained \
+            to target Droplets.
         droplet_ids (obj:`list` of `int`): A list of IDs representing \
             Droplets to be added to the Load Balancer (mutually \
             exclusive with 'tag')
@@ -112,6 +120,7 @@ class LoadBalancer(BaseAPI):
         * id (str): An unique identifier for a LoadBalancer
         * ip (str): Public IP address for a LoadBalancer
         * region (str): The slug identifier for a DigitalOcean region
+        * size (str): The size of the load balancer
         * algorithm (str, optional): The load balancing algorithm to be \
               used. Currently, it must be either "round_robin" or \
               "least_connections"
@@ -121,6 +130,11 @@ class LoadBalancer(BaseAPI):
         * redirect_http_to_https (bool, optional): A boolean indicating \
               whether HTTP requests to the Load Balancer should be \
               redirected to HTTPS
+        * enable_proxy_protocol (bool, optional): A boolean value indicating \
+              whether PROXY Protocol is in use
+        * enable_backend_keepalive (bool, optional): A boolean value \
+              indicating whether HTTP keepalive connections are maintained \
+              to target Droplets.
         * droplet_ids (obj:`list` of `int`): A list of IDs representing \
               Droplets to be added to the Load Balancer
         * tag (str): A string representing a DigitalOcean Droplet tag
@@ -132,11 +146,14 @@ class LoadBalancer(BaseAPI):
         self.id = None
         self.name = None
         self.region = None
+        self.size = None
         self.algorithm = None
         self.forwarding_rules = []
         self.health_check = None
         self.sticky_sessions = None
         self.redirect_http_to_https = False
+        self.enable_proxy_protocol = False
+        self.enable_backend_keepalive = False
         self.droplet_ids = []
         self.tag = None
         self.status = None
@@ -195,6 +212,9 @@ class LoadBalancer(BaseAPI):
         Args:
             name (str): The Load Balancer's name
             region (str): The slug identifier for a DigitalOcean region
+            size (str): The size of the load balancer. The available sizes
+                are "lb-small", "lb-medium", or "lb-large". Once you have
+                created a load balancer, you can't change its size
             algorithm (str, optional): The load balancing algorithm to be
                 used. Currently, it must be either "round_robin" or
                 "least_connections"
@@ -204,6 +224,11 @@ class LoadBalancer(BaseAPI):
             redirect_http_to_https (bool, optional): A boolean indicating
                 whether HTTP requests to the Load Balancer should be
                 redirected to HTTPS
+            enable_proxy_protocol (bool, optional): A boolean value indicating
+                whether PROXY Protocol is in use
+            enable_backend_keepalive (bool, optional): A boolean value
+                indicating whether HTTP keepalive connections are maintained
+                to target Droplets.
             droplet_ids (obj:`list` of `int`): A list of IDs representing
                 Droplets to be added to the Load Balancer (mutually
                 exclusive with 'tag')
@@ -215,8 +240,11 @@ class LoadBalancer(BaseAPI):
         rules_dict = [rule.__dict__ for rule in self.forwarding_rules]
 
         params = {'name': self.name, 'region': self.region,
+                  'size': self.size,
                   'forwarding_rules': rules_dict,
                   'redirect_http_to_https': self.redirect_http_to_https,
+                  'enable_proxy_protocol': self.enable_proxy_protocol,
+                  'enable_backend_keepalive': self.enable_backend_keepalive,
                   'vpc_uuid': self.vpc_uuid}
 
         if self.droplet_ids and self.tag:
@@ -261,6 +289,8 @@ class LoadBalancer(BaseAPI):
             'region': self.region['slug'],
             'forwarding_rules': forwarding_rules,
             'redirect_http_to_https': self.redirect_http_to_https,
+            'enable_proxy_protocol': self.enable_proxy_protocol,
+            'enable_backend_keepalive': self.enable_backend_keepalive,
             'vpc_uuid': self.vpc_uuid
         }
 

--- a/digitalocean/LoadBalancer.py
+++ b/digitalocean/LoadBalancer.py
@@ -267,6 +267,7 @@ class LoadBalancer(BaseAPI):
             self.id = data['load_balancer']['id']
             self.ip = data['load_balancer']['ip']
             self.algorithm = data['load_balancer']['algorithm']
+            self.size = data['load_balancer']['size']
             self.health_check = HealthCheck(
                 **data['load_balancer']['health_check'])
             self.sticky_sessions = StickySessions(
@@ -274,6 +275,9 @@ class LoadBalancer(BaseAPI):
             self.droplet_ids = data['load_balancer']['droplet_ids']
             self.status = data['load_balancer']['status']
             self.created_at = data['load_balancer']['created_at']
+            self.redirect_http_to_https = data['load_balancer']['redirect_http_to_https']
+            self.enable_proxy_protocol = data['load_balancer']['enable_proxy_protocol']
+            self.enable_backend_keepalive = data['load_balancer']['enable_backend_keepalive']
             self.vpc_uuid = data['load_balancer']['vpc_uuid']
 
         return self

--- a/digitalocean/tests/data/loadbalancer/all.json
+++ b/digitalocean/tests/data/loadbalancer/all.json
@@ -1,151 +1,82 @@
 {
   "load_balancers": [
-  {
-    "id": "4de2ac7b-495b-4884-9e69-1050d6793cd4",
-    "name": "example-lb-02",
-    "ip": "104.131.186.248",
-    "algorithm": "round_robin",
-    "status": "new",
-    "created_at": "2017-02-01T22:22:58Z",
-    "forwarding_rules": [
-      {
-        "entry_protocol": "http",
-        "entry_port": 80,
-        "target_protocol": "http",
-        "target_port": 80,
-        "certificate_id": "",
-        "tls_passthrough": false
+    {
+      "id": "4de7ac8b-495b-4884-9a69-1050c6793cd6",
+      "name": "example-lb-01",
+      "ip": "104.131.186.241",
+      "size": "lb-small",
+      "algorithm": "round_robin",
+      "status": "new",
+      "created_at": "2017-02-01T22:22:58Z",
+      "forwarding_rules": [
+        {
+          "entry_protocol": "http",
+          "entry_port": 80,
+          "target_protocol": "http",
+          "target_port": 80,
+          "certificate_id": "",
+          "tls_passthrough": false
+        },
+        {
+          "entry_protocol": "https",
+          "entry_port": 444,
+          "target_protocol": "https",
+          "target_port": 443,
+          "certificate_id": "",
+          "tls_passthrough": true
+        }
+      ],
+      "health_check": {
+        "protocol": "http",
+        "port": 80,
+        "path": "/",
+        "check_interval_seconds": 10,
+        "response_timeout_seconds": 5,
+        "healthy_threshold": 5,
+        "unhealthy_threshold": 3
       },
-      {
-        "entry_protocol": "https",
-        "entry_port": 444,
-        "target_protocol": "https",
-        "target_port": 443,
-        "certificate_id": "",
-        "tls_passthrough": true
-      }
-    ],
-    "health_check": {
-      "protocol": "http",
-      "port": 80,
-      "path": "/",
-      "check_interval_seconds": 10,
-      "response_timeout_seconds": 5,
-      "healthy_threshold": 5,
-      "unhealthy_threshold": 3
-    },
-    "sticky_sessions": {
-      "type": "none"
-    },
-    "region": {
-      "name": "New York 3",
-      "slug": "nyc3",
-      "sizes": [
-        "512mb",
-        "1gb",
-        "2gb",
-        "4gb",
-        "8gb",
-        "16gb",
-        "m-16gb",
-        "32gb",
-        "m-32gb",
-        "48gb",
-        "m-64gb",
-        "64gb",
-        "m-128gb",
-        "m-224gb"
-      ],
-      "features": [
-        "private_networking",
-        "backups",
-        "ipv6",
-        "metadata",
-        "install_agent"
-      ],
-      "available": true
-    },
-    "tag": "web",
-    "droplet_ids": [
-      3164444,
-      3164445
-    ],
-    "redirect_http_to_https": false,
-    "vpc_uuid": "08187eaa-90eb-40d6-a8f0-0222b28ded72"
-  },
-  {
-    "id": "4de7ac8b-495b-4884-9a69-1050c6793cd6",
-    "name": "example-lb-01",
-    "ip": "104.131.186.241",
-    "algorithm": "round_robin",
-    "status": "new",
-    "created_at": "2017-02-01T22:22:58Z",
-    "forwarding_rules": [
-      {
-        "entry_protocol": "http",
-        "entry_port": 80,
-        "target_protocol": "http",
-        "target_port": 80,
-        "certificate_id": "",
-        "tls_passthrough": false
+      "sticky_sessions": {
+        "type": "none"
       },
-      {
-        "entry_protocol": "https",
-        "entry_port": 444,
-        "target_protocol": "https",
-        "target_port": 443,
-        "certificate_id": "",
-        "tls_passthrough": true
-      }
-    ],
-    "health_check": {
-      "protocol": "http",
-      "port": 80,
-      "path": "/",
-      "check_interval_seconds": 10,
-      "response_timeout_seconds": 5,
-      "healthy_threshold": 5,
-      "unhealthy_threshold": 3
-    },
-    "sticky_sessions": {
-      "type": "none"
-    },
-    "region": {
-      "name": "New York 3",
-      "slug": "nyc3",
-      "sizes": [
-        "512mb",
-        "1gb",
-        "2gb",
-        "4gb",
-        "8gb",
-        "16gb",
-        "m-16gb",
-        "32gb",
-        "m-32gb",
-        "48gb",
-        "m-64gb",
-        "64gb",
-        "m-128gb",
-        "m-224gb"
+      "region": {
+        "name": "New York 3",
+        "slug": "nyc3",
+        "sizes": [
+          "s-1vcpu-1gb",
+          "s-1vcpu-2gb",
+          "s-1vcpu-3gb",
+          "s-2vcpu-2gb",
+          "s-3vcpu-1gb",
+          "s-2vcpu-4gb",
+          "s-4vcpu-8gb",
+          "s-6vcpu-16gb",
+          "s-8vcpu-32gb",
+          "s-12vcpu-48gb",
+          "s-16vcpu-64gb",
+          "s-20vcpu-96gb",
+          "s-24vcpu-128gb",
+          "s-32vcpu-192gb"
+        ],
+        "features": [
+          "private_networking",
+          "backups",
+          "ipv6",
+          "metadata",
+          "install_agent"
+        ],
+        "available": true
+      },
+      "tag": "",
+      "droplet_ids": [
+        3164444,
+        3164445
       ],
-      "features": [
-        "private_networking",
-        "backups",
-        "ipv6",
-        "metadata",
-        "install_agent"
-      ],
-      "available": true
-    },
-    "tag": "",
-    "droplet_ids": [
-      3164444,
-      3164445
-    ],
-    "redirect_http_to_https": false,
-    "vpc_uuid": "08187eaa-90eb-40d6-a8f0-0222b28ded72"
-  }],
+      "redirect_http_to_https": false,
+      "enable_proxy_protocol": false,
+      "enable_backend_keepalive": false,
+      "vpc_uuid": "c33931f2-a26a-4e61-b85c-4e95a2ec431b"
+    }
+  ],
   "links": {
   },
   "meta": {

--- a/digitalocean/tests/data/loadbalancer/save.json
+++ b/digitalocean/tests/data/loadbalancer/save.json
@@ -42,20 +42,20 @@
       "name": "New York 3",
       "slug": "nyc3",
       "sizes": [
-        "512mb",
-        "1gb",
-        "2gb",
-        "4gb",
-        "8gb",
-        "16gb",
-        "m-16gb",
-        "32gb",
-        "m-32gb",
-        "48gb",
-        "m-64gb",
-        "64gb",
-        "m-128gb",
-        "m-224gb"
+        "s-1vcpu-1gb",
+        "s-1vcpu-2gb",
+        "s-1vcpu-3gb",
+        "s-2vcpu-2gb",
+        "s-3vcpu-1gb",
+        "s-2vcpu-4gb",
+        "s-4vcpu-8gb",
+        "s-6vcpu-16gb",
+        "s-8vcpu-32gb",
+        "s-12vcpu-48gb",
+        "s-16vcpu-64gb",
+        "s-20vcpu-96gb",
+        "s-24vcpu-128gb",
+        "s-32vcpu-192gb"
       ],
       "features": [
         "private_networking",
@@ -72,6 +72,8 @@
       34153250
     ],
     "redirect_http_to_https": false,
-    "vpc_uuid": "08187eaa-90eb-40d6-a8f0-0222b28ded72"
+    "enable_proxy_protocol": false,
+    "enable_backend_keepalive": false,
+    "vpc_uuid": "c33931f2-a26a-4e61-b85c-4e95a2ec431b"
   }
 }

--- a/digitalocean/tests/data/loadbalancer/save.json
+++ b/digitalocean/tests/data/loadbalancer/save.json
@@ -71,9 +71,9 @@
       34153248,
       34153250
     ],
-    "redirect_http_to_https": false,
-    "enable_proxy_protocol": false,
-    "enable_backend_keepalive": false,
+    "redirect_http_to_https": true,
+    "enable_proxy_protocol": true,
+    "enable_backend_keepalive": true,
     "vpc_uuid": "c33931f2-a26a-4e61-b85c-4e95a2ec431b"
   }
 }

--- a/digitalocean/tests/data/loadbalancer/single.json
+++ b/digitalocean/tests/data/loadbalancer/single.json
@@ -3,6 +3,7 @@
     "id": "4de7ac8b-495b-4884-9a69-1050c6793cd6",
     "name": "example-lb-01",
     "ip": "104.131.186.241",
+    "size": "lb-small",
     "algorithm": "round_robin",
     "status": "new",
     "created_at": "2017-02-01T22:22:58Z",
@@ -40,20 +41,20 @@
       "name": "New York 3",
       "slug": "nyc3",
       "sizes": [
-        "512mb",
-        "1gb",
-        "2gb",
-        "4gb",
-        "8gb",
-        "16gb",
-        "m-16gb",
-        "32gb",
-        "m-32gb",
-        "48gb",
-        "m-64gb",
-        "64gb",
-        "m-128gb",
-        "m-224gb"
+        "s-1vcpu-1gb",
+        "s-1vcpu-2gb",
+        "s-1vcpu-3gb",
+        "s-2vcpu-2gb",
+        "s-3vcpu-1gb",
+        "s-2vcpu-4gb",
+        "s-4vcpu-8gb",
+        "s-6vcpu-16gb",
+        "s-8vcpu-32gb",
+        "s-12vcpu-48gb",
+        "s-16vcpu-64gb",
+        "s-20vcpu-96gb",
+        "s-24vcpu-128gb",
+        "s-32vcpu-192gb"
       ],
       "features": [
         "private_networking",
@@ -70,6 +71,8 @@
       3164445
     ],
     "redirect_http_to_https": false,
-    "vpc_uuid": "08187eaa-90eb-40d6-a8f0-0222b28ded72"
+    "enable_proxy_protocol": false,
+    "enable_backend_keepalive": false,
+    "vpc_uuid": "c33931f2-a26a-4e61-b85c-4e95a2ec431b"
   }
 }

--- a/digitalocean/tests/data/loadbalancer/single_tag.json
+++ b/digitalocean/tests/data/loadbalancer/single_tag.json
@@ -1,8 +1,9 @@
 {
   "load_balancer": {
-    "id": "4de2ac7b-495b-4884-9e69-1050d6793cd4",
-    "name": "example-lb-02",
+    "id": "4de7ac8b-495b-4884-9a69-1050c6793cd6",
+    "name": "example-lb-01",
     "ip": "104.131.186.248",
+    "size": "lb-small",
     "algorithm": "round_robin",
     "status": "new",
     "created_at": "2017-02-01T22:22:58Z",
@@ -40,20 +41,20 @@
       "name": "New York 3",
       "slug": "nyc3",
       "sizes": [
-        "512mb",
-        "1gb",
-        "2gb",
-        "4gb",
-        "8gb",
-        "16gb",
-        "m-16gb",
-        "32gb",
-        "m-32gb",
-        "48gb",
-        "m-64gb",
-        "64gb",
-        "m-128gb",
-        "m-224gb"
+        "s-1vcpu-1gb",
+        "s-1vcpu-2gb",
+        "s-1vcpu-3gb",
+        "s-2vcpu-2gb",
+        "s-3vcpu-1gb",
+        "s-2vcpu-4gb",
+        "s-4vcpu-8gb",
+        "s-6vcpu-16gb",
+        "s-8vcpu-32gb",
+        "s-12vcpu-48gb",
+        "s-16vcpu-64gb",
+        "s-20vcpu-96gb",
+        "s-24vcpu-128gb",
+        "s-32vcpu-192gb"
       ],
       "features": [
         "private_networking",
@@ -64,12 +65,14 @@
       ],
       "available": true
     },
-    "tag": "web",
     "droplet_ids": [
       3164444,
       3164445
     ],
+    "tag": "web:prod",
     "redirect_http_to_https": false,
-    "vpc_uuid": "08187eaa-90eb-40d6-a8f0-0222b28ded72"
+    "enable_proxy_protocol": false,
+    "enable_backend_keepalive": false,
+    "vpc_uuid": "c33931f2-a26a-4e61-b85c-4e95a2ec431b"
   }
 }

--- a/digitalocean/tests/test_load_balancer.py
+++ b/digitalocean/tests/test_load_balancer.py
@@ -256,6 +256,9 @@ class TestLoadBalancer(BaseTest):
         self.lb.sticky_sessions.cookie_ttl_seconds = 300
         self.lb.droplet_ids = [34153248, 34153250]
         self.lb.vpc_uuid = self.vpc_uuid
+        self.lb.redirect_http_to_https = True
+        self.lb.enable_proxy_protocol = True
+        self.lb.enable_backend_keepalive = True
         res = self.lb.save()
 
         lb = digitalocean.LoadBalancer(**res['load_balancer'])
@@ -292,9 +295,9 @@ class TestLoadBalancer(BaseTest):
         self.assertEqual(lb.sticky_sessions.cookie_ttl_seconds, 300)
         self.assertEqual(lb.droplet_ids, [34153248, 34153250])
         self.assertEqual(lb.tag, '')
-        self.assertEqual(lb.redirect_http_to_https, False)
-        self.assertEqual(lb.enable_proxy_protocol, False)
-        self.assertEqual(lb.enable_backend_keepalive, False)
+        self.assertEqual(lb.redirect_http_to_https, True)
+        self.assertEqual(lb.enable_proxy_protocol, True)
+        self.assertEqual(lb.enable_backend_keepalive, True)
         self.assertEqual(self.lb.vpc_uuid, self.vpc_uuid)
 
     @responses.activate

--- a/digitalocean/tests/test_load_balancer.py
+++ b/digitalocean/tests/test_load_balancer.py
@@ -31,6 +31,7 @@ class TestLoadBalancer(BaseTest):
         self.assert_get_url_equal(responses.calls[0].request.url, url)
         self.assertEqual(self.lb.id, self.lb_id)
         self.assertEqual(self.lb.region['slug'], 'nyc3')
+        self.assertEqual(self.lb.size, 'lb-small')
         self.assertEqual(self.lb.algorithm, 'round_robin')
         self.assertEqual(self.lb.ip, '104.131.186.241')
         self.assertEqual(self.lb.name, 'example-lb-01')
@@ -44,6 +45,9 @@ class TestLoadBalancer(BaseTest):
         self.assertEqual(self.lb.health_check.port, 80)
         self.assertEqual(self.lb.sticky_sessions.type, 'none')
         self.assertEqual(self.lb.droplet_ids, [3164444, 3164445])
+        self.assertEqual(self.lb.redirect_http_to_https, False)
+        self.assertEqual(self.lb.enable_proxy_protocol, False)
+        self.assertEqual(self.lb.enable_backend_keepalive, False)
         self.assertEqual(self.lb.vpc_uuid, self.vpc_uuid)
 
     @responses.activate
@@ -70,6 +74,7 @@ class TestLoadBalancer(BaseTest):
         sticky = digitalocean.StickySessions(type='none')
         lb = digitalocean.LoadBalancer(name='example-lb-01', region='nyc3',
                                        algorithm='round_robin',
+                                       size='lb-small',
                                        forwarding_rules=[rule1, rule2],
                                        health_check=check,
                                        sticky_sessions=sticky,
@@ -84,6 +89,7 @@ class TestLoadBalancer(BaseTest):
         self.assertEqual(lb.algorithm, 'round_robin')
         self.assertEqual(lb.ip, '104.131.186.241')
         self.assertEqual(lb.name, 'example-lb-01')
+        self.assertEqual(lb.size, 'lb-small')
         self.assertEqual(len(resp_rules), 2)
         self.assertEqual(resp_rules[0].entry_protocol, 'http')
         self.assertEqual(resp_rules[0].entry_port, 80)
@@ -94,6 +100,9 @@ class TestLoadBalancer(BaseTest):
         self.assertEqual(lb.health_check.port, 80)
         self.assertEqual(lb.sticky_sessions.type, 'none')
         self.assertEqual(lb.droplet_ids, [3164444, 3164445])
+        self.assertEqual(lb.redirect_http_to_https, False)
+        self.assertEqual(lb.enable_proxy_protocol, False)
+        self.assertEqual(lb.enable_backend_keepalive, False)
         self.assertEqual(lb.vpc_uuid, self.vpc_uuid)
 
     @responses.activate
@@ -120,6 +129,7 @@ class TestLoadBalancer(BaseTest):
         sticky = digitalocean.StickySessions(type='none')
         lb = digitalocean.LoadBalancer(name='example-lb-01', region='nyc3',
                                        algorithm='round_robin',
+                                       size='lb-small',
                                        forwarding_rules=[rule1, rule2],
                                        health_check=check,
                                        sticky_sessions=sticky,
@@ -135,6 +145,7 @@ class TestLoadBalancer(BaseTest):
         self.assertEqual(lb.algorithm, 'round_robin')
         self.assertEqual(lb.ip, '104.131.186.248')
         self.assertEqual(lb.name, 'example-lb-01')
+        self.assertEqual(lb.size, 'lb-small')
         self.assertEqual(len(resp_rules), 2)
         self.assertEqual(resp_rules[0].entry_protocol, 'http')
         self.assertEqual(resp_rules[0].entry_port, 80)
@@ -146,6 +157,9 @@ class TestLoadBalancer(BaseTest):
         self.assertEqual(lb.sticky_sessions.type, 'none')
         self.assertEqual(lb.tag, 'web:prod')
         self.assertEqual(lb.droplet_ids, [3164444, 3164445])
+        self.assertEqual(lb.redirect_http_to_https, False)
+        self.assertEqual(lb.enable_proxy_protocol, False)
+        self.assertEqual(lb.enable_backend_keepalive, False)
         self.assertEqual(lb.vpc_uuid, self.vpc_uuid)
 
     @responses.activate
@@ -167,6 +181,7 @@ class TestLoadBalancer(BaseTest):
         sticky = digitalocean.StickySessions(type='none')
         lb = digitalocean.LoadBalancer(name='example-lb-01', region='nyc3',
                                        algorithm='round_robin',
+                                       size='lb-small',
                                        forwarding_rules=[rule],
                                        health_check=check,
                                        sticky_sessions=sticky,
@@ -223,6 +238,8 @@ class TestLoadBalancer(BaseTest):
         self.assertEqual(self.lb.droplet_ids, [3164444, 3164445])
         self.assertEqual(self.lb.tag, '')
         self.assertEqual(self.lb.redirect_http_to_https, False)
+        self.assertEqual(self.lb.enable_proxy_protocol, False)
+        self.assertEqual(self.lb.enable_backend_keepalive, False)
         self.assertEqual(self.lb.vpc_uuid, self.vpc_uuid)
 
         data2 = self.load_from_file('loadbalancer/save.json')
@@ -276,6 +293,8 @@ class TestLoadBalancer(BaseTest):
         self.assertEqual(lb.droplet_ids, [34153248, 34153250])
         self.assertEqual(lb.tag, '')
         self.assertEqual(lb.redirect_http_to_https, False)
+        self.assertEqual(lb.enable_proxy_protocol, False)
+        self.assertEqual(lb.enable_backend_keepalive, False)
         self.assertEqual(self.lb.vpc_uuid, self.vpc_uuid)
 
     @responses.activate

--- a/digitalocean/tests/test_load_balancer.py
+++ b/digitalocean/tests/test_load_balancer.py
@@ -11,7 +11,7 @@ class TestLoadBalancer(BaseTest):
     def setUp(self):
         super(TestLoadBalancer, self).setUp()
         self.lb_id = '4de7ac8b-495b-4884-9a69-1050c6793cd6'
-        self.vpc_uuid = "08187eaa-90eb-40d6-a8f0-0222b28ded72"
+        self.vpc_uuid = "c33931f2-a26a-4e61-b85c-4e95a2ec431b"
         self.lb = digitalocean.LoadBalancer(id=self.lb_id, token=self.token)
 
     @responses.activate
@@ -124,14 +124,14 @@ class TestLoadBalancer(BaseTest):
                                        health_check=check,
                                        sticky_sessions=sticky,
                                        redirect_http_to_https=False,
-                                       tag='web',
+                                       tag='web:prod',
                                        vpc_uuid=self.vpc_uuid,
                                        token=self.token).create()
         resp_rules = lb.forwarding_rules
 
         self.assertEqual(responses.calls[0].request.url,
                          self.base_url + 'load_balancers')
-        self.assertEqual(lb.id, '4de2ac7b-495b-4884-9e69-1050d6793cd4')
+        self.assertEqual(lb.id, '4de7ac8b-495b-4884-9a69-1050c6793cd6')
         self.assertEqual(lb.algorithm, 'round_robin')
         self.assertEqual(lb.ip, '104.131.186.248')
         self.assertEqual(lb.name, 'example-lb-01')
@@ -144,7 +144,7 @@ class TestLoadBalancer(BaseTest):
         self.assertEqual(lb.health_check.protocol, 'http')
         self.assertEqual(lb.health_check.port, 80)
         self.assertEqual(lb.sticky_sessions.type, 'none')
-        self.assertEqual(lb.tag, 'web')
+        self.assertEqual(lb.tag, 'web:prod')
         self.assertEqual(lb.droplet_ids, [3164444, 3164445])
         self.assertEqual(lb.vpc_uuid, self.vpc_uuid)
 
@@ -171,7 +171,7 @@ class TestLoadBalancer(BaseTest):
                                        health_check=check,
                                        sticky_sessions=sticky,
                                        redirect_http_to_https=False,
-                                       tag='web',
+                                       tag='web:prod',
                                        droplet_ids=[123456, 789456],
                                        vpc_uuid=self.vpc_uuid,
                                        token=self.token)

--- a/digitalocean/tests/test_manager.py
+++ b/digitalocean/tests/test_manager.py
@@ -451,10 +451,10 @@ class TestManager(BaseTest):
         lbs = self.manager.get_all_load_balancers()
         resp_rules = lbs[0].forwarding_rules[0]
 
-        self.assertEqual(lbs[0].id, '4de2ac7b-495b-4884-9e69-1050d6793cd4')
+        self.assertEqual(lbs[0].id, '4de7ac8b-495b-4884-9a69-1050c6793cd6')
         self.assertEqual(lbs[0].algorithm, 'round_robin')
-        self.assertEqual(lbs[0].ip, '104.131.186.248')
-        self.assertEqual(lbs[0].name, 'example-lb-02')
+        self.assertEqual(lbs[0].ip, '104.131.186.241')
+        self.assertEqual(lbs[0].name, 'example-lb-01')
         self.assertEqual(len(lbs[0].forwarding_rules), 2)
         self.assertEqual(resp_rules.entry_protocol, 'http')
         self.assertEqual(resp_rules.entry_port, 80)
@@ -464,7 +464,7 @@ class TestManager(BaseTest):
         self.assertEqual(lbs[0].health_check.protocol, 'http')
         self.assertEqual(lbs[0].health_check.port, 80)
         self.assertEqual(lbs[0].sticky_sessions.type, 'none')
-        self.assertEqual(lbs[0].tag, 'web')
+        self.assertEqual(lbs[0].tag, '')
         self.assertEqual(lbs[0].droplet_ids, [3164444, 3164445])
 
     @responses.activate


### PR DESCRIPTION
The DigitalOcean API now includes support for the following new values for loadbalancers:

- size
- enable_proxy_protocol
- enable_backend_keepalive

Without these things added to the library when you save a loadbalncer these values (except size) are set to the default (false). Adding size allows users to create loadbalaners of different sizes than the default of 'lb-small'

I've also updated the test sample files to the updated version provided in the DigitalOcean API documentation.