### PR TITLE
Show Tag.name in the Tag's string representation

### DIFF
--- a/digitalocean/Tag.py
+++ b/digitalocean/Tag.py
@@ -187,3 +187,7 @@ class Tag(BaseAPI):
         
         return False
 
+
+    def __str__(self):
+        return "<Tag: %s>" % self.name
+


### PR DESCRIPTION
Calls to `digitalocean.Manager.get_all_tags()` will result in lists that look like `[<Tag>, <Tag>, <Tag>, ...]`, which is not very easy to work with.

This way, `Tags` will have their name as part of the string representation: `[<Tag: foo>, <Tag: bar>, <Tag: baz>, ...]`.