### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ droplet.create()
 
 ### Creating a Firewall
 
-This example creates a firewall that only accepts inbound tcp traffic on port 80 from a specific load balancer and allows outbout tcp traffic on all ports to all addresses.
+This example creates a firewall that only accepts inbound tcp traffic on port 80 from a specific load balancer and allows outbound tcp traffic on all ports to all addresses.
 
 ```python
 from digitalocean import Firewall, InboundRule, OutboundRule, Destinations, Sources
@@ -375,7 +375,7 @@ print(manager.ratelimit_limit)
 
 ## Session customization
 
-You can take advandtage of the [requests](http://docs.python-requests.org/en/master/) library and configure the HTTP client under python-digitalocean.
+You can take advantage of the [requests](http://docs.python-requests.org/en/master/) library and configure the HTTP client under python-digitalocean.
 
 ### Configure retries in case of connection error
 

--- a/digitalocean/Domain.py
+++ b/digitalocean/Domain.py
@@ -88,7 +88,7 @@ class Domain(BaseAPI):
 
     def create(self):
         """
-            Create new doamin
+            Create new domain
         """
         # URL https://api.digitalocean.com/v2/domains
         data = {

--- a/digitalocean/LoadBalancer.py
+++ b/digitalocean/LoadBalancer.py
@@ -160,7 +160,7 @@ class LoadBalancer(BaseAPI):
 
     def load(self):
         """
-        Loads updated attributues for a LoadBalancer object.
+        Loads updated attributes for a LoadBalancer object.
 
         Requires self.id to be set.
         """

--- a/digitalocean/VPC.py
+++ b/digitalocean/VPC.py
@@ -25,7 +25,7 @@ class VPC(BaseAPI):
             CIDR notation
         * urn (str): The uniform resource name (URN) for the VPC
         * created_at (str): A string that represents when the VPC was created
-        * default (bool): A boolen representing whether or not the VPC is the \
+        * default (bool): A boolean representing whether or not the VPC is the \
             user's default VPC for the region
     """
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
There are small typos in:
- README.md
- digitalocean/Domain.py
- digitalocean/LoadBalancer.py
- digitalocean/VPC.py

Fixes:
- Should read `domain` rather than `doamin`.
- Should read `boolean` rather than `boolen`.
- Should read `attributes` rather than `attributues`.
- Should read `advantage` rather than `advandtage`.

Closes #339