### PR TITLE
Add name parameter to manager get all volumes

### DIFF
--- a/digitalocean/Manager.py
+++ b/digitalocean/Manager.py
@@ -345,6 +345,12 @@ class Manager(BaseAPI):
     def get_all_volumes(self, region=None, name=None):
         """
             This function returns a list of Volume objects.
+
+            Args:
+                region (str, optional): Restrict results to volumes \
+                    available in a specific region. e.g. nyc1
+                name (str, optional): List volumes on your account that \
+                    match a specified name. e.g. example-volume
         """
         url = "volumes"
         parameters = []

--- a/digitalocean/Manager.py
+++ b/digitalocean/Manager.py
@@ -342,14 +342,18 @@ class Manager(BaseAPI):
             for snapshot in data['snapshots']
         ]
 
-    def get_all_volumes(self, region=None):
+    def get_all_volumes(self, region=None, name=None):
         """
             This function returns a list of Volume objects.
         """
+        url = "volumes"
+        parameters = []
         if region:
-            url = "volumes?region={}".format(region)
-        else:
-            url = "volumes"
+            parameters.append("region={}".format(region))
+        if name:
+            parameters.append("name={}".format(name))
+        if len(parameters) > 0:
+            url += "?" + "&".join(parameters)
         data = self.get_data(url)
         volumes = list()
         for jsoned in data['volumes']:

--- a/digitalocean/tests/test_manager.py
+++ b/digitalocean/tests/test_manager.py
@@ -536,6 +536,25 @@ class TestManager(BaseTest):
         self.assertEqual(len(volumes), 1)
 
     @responses.activate
+    def test_get_named_volumes(self):
+        data = json.loads(self.load_from_file('volumes/all.json'))
+        data["volumes"] = [
+            volume for volume in data["volumes"]
+            if volume["name"] == "another-example"]
+
+        url = self.base_url + "volumes?name=another-example&per_page=200"
+        responses.add(responses.GET, url,
+                      match_querystring=True,
+                      body=json.dumps(data),
+                      status=200,
+                      content_type='application/json')
+        volumes = self.manager.get_all_volumes(name="another-example")
+
+        self.assertEqual(volumes[0].id, "2d2967ff-491d-11e6-860c-000f53315870")
+        self.assertEqual(volumes[0].name, 'another-example')
+        self.assertEqual(len(volumes), 1)
+
+    @responses.activate
     def test_get_all_tags(self):
         data = self.load_from_file('tags/all.json')
 


### PR DESCRIPTION
the API lets you filter volumes by region and name. the former is already in this library. the latter is missing from the library, and this PR adds it. this PR also adds a test for the new parameter.
