### PR TITLE
Add CDN Endpoint API to create, update and delete.

### DIFF
--- a/digitalocean/CDNEndpoint.py
+++ b/digitalocean/CDNEndpoint.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+from .baseapi import BaseAPI, POST, DELETE, PUT
+
+
+class CDNEndpoint(BaseAPI):
+    """
+    An object representing an DigitalOcean CDN Endpoint.
+
+    Args:
+        origin (str): The fully qualified domain name (FQDN) for the
+            origin server which provides the content for the CDN.
+            This is currently restricted to a Space.
+        ttl (int): The amount of time the content is cached by the
+            CDN's edge servers in seconds. TTL must be one of
+            60, 600, 3600, 86400, or 604800.
+            Defaults to 3600 (one hour) when excluded.
+        certificate_id (str): The ID of a DigitalOcean managed TLS
+            certificate used for SSL when a custom subdomain is provided.
+        custom_domain (str): The fully qualified domain name (FQDN) of the
+            custom subdomain used with the CDN endpoint.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.id = None
+        self.origin = None
+        self.endpoint = None
+        self.created_at = None
+        self.certificate_id = None
+        self.custom_domain = None
+        self.ttl = None
+
+        super(CDNEndpoint, self).__init__(*args, **kwargs)
+
+    @classmethod
+    def get_object(cls, api_token, cdn_endpoint_id):
+        """Class method that will return a CDN Endpoint object by ID.
+
+        Args:
+            api_token (str): token
+            cdn_endpoint_id (int): CDN Endpoint id
+        """
+        cdn_endpoint = cls(token=api_token, id=cdn_endpoint_id)
+        cdn_endpoint.load()
+        return cdn_endpoint
+
+    def load(self):
+        """
+           Fetch data about CDN Endpoints - use this instead of get_data()
+        """
+        cdn_endpoints = self.get_data("cdn/endpoints/%s" % self.id)
+        cdn_endpoint = cdn_endpoints['endpoint']
+
+        for attr in cdn_endpoint.keys():
+            setattr(self, attr, cdn_endpoint[attr])
+
+        return self
+
+    def create(self, **kwargs):
+        """
+            Create the CDN Endpoint.
+        """
+        for attr in kwargs.keys():
+            setattr(self, attr, kwargs[attr])
+
+        params = {
+            'origin': self.origin,
+            'ttl': self.ttl or 3600,
+            'certificated_id': self.certificate_id,
+            'custom_domain': self.custom_domain
+        }
+
+        output = self.get_data("cdn/endpoints", type="POST", params=params)
+        if output:
+            self.id = output['endpoint']['id']
+            self.created_at = output['endpoint']['created_at']
+            self.endpoint = output['endpoint']['endpoint']
+
+
+    def delete(self):
+        """
+            Delete the CDN Endpoint.
+        """
+        return self.get_data("cdn/endpoints/%s" % self.id, type="DELETE", params=False)
+
+    def save(self):
+        """
+            Save existing CDN Endpoint
+        """
+        data = {
+            'ttl': self.ttl,
+            'certificate_id': self.certificate_id,
+            'custom_domain': self.custom_domain,
+        }
+        return self.get_data(
+            "cdn/endpoints/%s" % self.id,
+            type=PUT,
+            params=data
+        )
+
+
+    def __str__(self):
+        return "<CDNEndpoints: %s %s>" % (self.id, self.origin)

--- a/digitalocean/Manager.py
+++ b/digitalocean/Manager.py
@@ -24,6 +24,8 @@ from .Tag import Tag
 from .Volume import Volume
 from .VPC import VPC
 from .Project import Project
+from .CDNEndpoint import CDNEndpoint
+
 
 class Manager(BaseAPI):
     def __init__(self, *args, **kwargs):
@@ -472,6 +474,27 @@ class Manager(BaseAPI):
         return Project.get_object(
             api_token=self.token,
             project_id="default",
+        )
+
+    def get_all_cdn_endpoints(self):
+        """
+            All the projects of the account
+        """
+        data = self.get_data("cdn/endpoints")
+        cdn_endpoints = list()
+        for jsoned in data['endpoints']:
+            cdn_endpoint = CDNEndpoint(**jsoned)
+            cdn_endpoint.token = self.token
+            cdn_endpoints.append(cdn_endpoint)
+        return cdn_endpoints
+
+    def get_cdn_endpoint(self, cdn_endpoint_id):
+        """
+            Return a Project by its ID.
+        """
+        return CDNEndpoint.get_object(
+            api_token=self.token,
+            cdn_endpoint_id=cdn_endpoint_id,
         )
 
     def __str__(self):

--- a/digitalocean/__init__.py
+++ b/digitalocean/__init__.py
@@ -30,3 +30,4 @@ from .Snapshot import Snapshot
 from .Project import Project
 from .Firewall import Firewall, InboundRule, OutboundRule, Destinations, Sources
 from .VPC import VPC
+from .CDNEndpoint import CDNEndpoint

--- a/digitalocean/baseapi.py
+++ b/digitalocean/baseapi.py
@@ -119,6 +119,10 @@ class BaseAPI(object):
                         'User-Agent': agent})
         kwargs = {'headers': headers, payload: transform(params)}
 
+        # Some requests do not require a body
+        if params is False:
+            del kwargs['data']
+
         timeout = self.get_timeout()
         if timeout:
             kwargs['timeout'] = timeout

--- a/digitalocean/tests/data/cdn_endpoints/all.json
+++ b/digitalocean/tests/data/cdn_endpoints/all.json
@@ -1,0 +1,17 @@
+{
+    "endpoints": [
+      {
+        "id": "19f06b6a-3ace-4315-b086-499a0e521b76",
+        "origin": "static-images.nyc3.digitaloceanspaces.com",
+        "endpoint": "static-images.nyc3.cdn.digitaloceanspaces.com",
+        "created_at": "2018-07-19T15:04:16Z",
+        "certificate_id": "892071a0-bb95-49bc-8021-3afd67a210bf",
+        "custom_domain": "static.example.com",
+        "ttl": 3600
+      }
+    ],
+    "links": {},
+    "meta": {
+      "total": 1
+    }
+}

--- a/digitalocean/tests/data/cdn_endpoints/create.json
+++ b/digitalocean/tests/data/cdn_endpoints/create.json
@@ -1,0 +1,9 @@
+{
+    "endpoint": {
+      "id": "19f06b6a-3ace-4315-b086-499a0e521b76",
+      "origin": "static-images.nyc3.digitaloceanspaces.com",
+      "endpoint": "static-images.nyc3.cdn.digitaloceanspaces.com",
+      "created_at": "2018-07-19T15:04:16Z",
+      "ttl": 3600
+    }
+}

--- a/digitalocean/tests/data/cdn_endpoints/single.json
+++ b/digitalocean/tests/data/cdn_endpoints/single.json
@@ -1,0 +1,9 @@
+{
+    "endpoint": {
+      "id": "19f06b6a-3ace-4315-b086-499a0e521b76",
+      "origin": "static-images.nyc3.digitaloceanspaces.com",
+      "endpoint": "static-images.nyc3.cdn.digitaloceanspaces.com",
+      "created_at": "2018-07-19T15:04:16Z",
+      "ttl": 3600
+    }
+}

--- a/digitalocean/tests/data/cdn_endpoints/update.json
+++ b/digitalocean/tests/data/cdn_endpoints/update.json
@@ -1,0 +1,9 @@
+{
+    "endpoint": {
+      "id": "19f06b6a-3ace-4315-b086-499a0e521b76",
+      "origin": "static-images.nyc3.digitaloceanspaces.com",
+      "endpoint": "static-images.nyc3.cdn.digitaloceanspaces.com",
+      "created_at": "2018-07-19T15:04:16Z",
+      "ttl": 60
+    }
+}

--- a/digitalocean/tests/test_cdn_endpoint.py
+++ b/digitalocean/tests/test_cdn_endpoint.py
@@ -1,0 +1,91 @@
+import json
+import unittest
+
+import responses
+
+import digitalocean
+from .BaseTest import BaseTest
+
+
+class TestCDNRecord(BaseTest):
+
+    def setUp(self):
+        super(TestCDNRecord, self).setUp()
+
+    @responses.activate
+    def test_load(self):
+        data = self.load_from_file('cdn_endpoints/single.json')
+
+        url = self.base_url + "cdn/endpoints/19f06b6a-3ace-4315-b086-499a0e521b76"
+        responses.add(responses.GET,
+                      url,
+                      body=data,
+                      status=200,
+                      content_type='application/json')
+        c = digitalocean.CDNEndpoint(id='19f06b6a-3ace-4315-b086-499a0e521b76', token=self.token).load()
+        self.assertEqual(c.id, '19f06b6a-3ace-4315-b086-499a0e521b76')
+        self.assertEqual(c.origin, 'static-images.nyc3.digitaloceanspaces.com')
+        self.assertEqual(c.endpoint, 'static-images.nyc3.cdn.digitaloceanspaces.com')
+        self.assertEqual(c.created_at, '2018-07-19T15:04:16Z')
+        self.assertEqual(c.ttl, 3600)
+
+    @responses.activate
+    def test_create(self):
+        data = self.load_from_file('cdn_endpoints/single.json')
+
+        url = self.base_url + "cdn/endpoints"
+        responses.add(responses.POST,
+                      url,
+                      body=data,
+                      status=201,
+                      content_type='application/json')
+
+        cdn_endpoint = digitalocean.CDNEndpoint(origin='static-images.nyc3.digitaloceanspaces.com', token=self.token)
+        cdn_endpoint.create()
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.base_url + "cdn/endpoints")
+        self.assertEqual(cdn_endpoint.origin, "static-images.nyc3.digitaloceanspaces.com")
+
+
+    @responses.activate
+    def test_delete(self):
+        url = self.base_url + "cdn/endpoints/19f06b6a-3ace-4315-b086-499a0e521b76"
+        responses.add(responses.DELETE,
+                      url,
+                      status=204,
+                      content_type='application/json')
+
+        cdn_endpoint = digitalocean.CDNEndpoint(id='19f06b6a-3ace-4315-b086-499a0e521b76', token=self.token)
+        cdn_endpoint.delete()
+
+        self.assertEqual(responses.calls[0].request.url,
+                         self.base_url + "cdn/endpoints/19f06b6a-3ace-4315-b086-499a0e521b76")
+        self.assertEqual(cdn_endpoint.id, '19f06b6a-3ace-4315-b086-499a0e521b76')
+
+    @responses.activate
+    def test_save(self):
+        data = self.load_from_file('cdn_endpoints/single.json')
+        url = self.base_url + "cdn/endpoints/19f06b6a-3ace-4315-b086-499a0e521b76"
+        responses.add(responses.GET,
+                      url,
+                      body=data,
+                      status=200,
+                      content_type='application/json')
+        c = digitalocean.CDNEndpoint(id='19f06b6a-3ace-4315-b086-499a0e521b76', token=self.token).load()
+        self.assertEqual(c.ttl, 3600)
+        c.ttl = 60
+
+        data = self.load_from_file('cdn_endpoints/update.json')
+        url = self.base_url + "cdn/endpoints/19f06b6a-3ace-4315-b086-499a0e521b76"
+        responses.add(responses.PUT,
+                      url,
+                      body=data,
+                      status=200,
+                      content_type='application/json')
+        c.save()
+        self.assertEqual(c.ttl, 60)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Updated manager to do not submit body params during request when params argument was set to False.

```
        if params is False:
            del kwargs['data']
```

The API will return an error when submitting params (even empty).

The default behaviour sets the “params" to an empty dict when its value is equal to None.

```
        if params is None:
            params = dict()
```

This does not work with the CDN Enpoints API. I did not want to change this behaviour since it was probably made because other API endpoints needed a body (even if empty).

I am aware that is not the most elegant solution though.